### PR TITLE
re-use static strings for paths

### DIFF
--- a/src/accounts/accounts_request.rs
+++ b/src/accounts/accounts_request.rs
@@ -1,4 +1,4 @@
-use crate::models::*;
+use crate::{BuildQueryParametersExt, models::*};
 
 use super::super::AssetType;
 use super::super::Order;
@@ -44,29 +44,17 @@ impl Request for AccountsRequest {
     }
 
     fn get_query_parameters(&self) -> String {
-        let mut query = vec![];
-        if let Some(sponsor) = &self.sponsor {
-            query.push(format!("sponsor={}", sponsor));
-        }
-        if let Some(signer) = &self.signer {
-            query.push(format!("signer={}", signer));
-        }
-        if let Some(asset) = &self.asset {
-            query.push(format!("asset={}", asset));
-        }
-        if let Some(cursor) = &self.cursor {
-            query.push(format!("cursor={}", cursor));
-        }
-        if let Some(limit) = &self.limit {
-            query.push(format!("limit={}", limit));
-        }
-        if let Some(order) = &self.order {
-            query.push(format!("order={}", order));
-        }
-        if let Some(liquidity_pool) = &self.liquidity_pool {
-            query.push(format!("liquidity_pool={}", liquidity_pool));
-        }
-        format!("{}{}", match query.is_empty() {true => "", false => "?"}, query.join("&"))
+        vec![
+            self.sponsor.as_ref().map(|s| format!("sponsor={}", s)),
+            self.signer.as_ref().map(|s| format!("signer={}", s)),
+            self.asset.as_ref().map(|a| format!("asset={}", a)),
+            self.cursor.as_ref().map(|c| format!("cursor={}", c)),
+            self.limit.as_ref().map(|l| format!("limit={}", l)),
+            self.order.as_ref().map(|o| format!("order={}", o)),
+            self.liquidity_pool
+                .as_ref()
+                .map(|lp| format!("liquidity_pool={}", lp)),
+        ].build_query_parameters()
     }
 
     fn build_url(&self, base_url: &str) -> String {

--- a/src/accounts/accounts_request.rs
+++ b/src/accounts/accounts_request.rs
@@ -43,10 +43,6 @@ impl Request for AccountsRequest {
         }
     }
 
-    fn get_path(&self) -> &str {
-        "/accounts"
-    }
-
     fn get_query_parameters(&self) -> String {
         let mut query = String::new();
         if let Some(sponsor) = &self.sponsor {
@@ -75,9 +71,9 @@ impl Request for AccountsRequest {
 
     fn build_url(&self, base_url: &str) -> String {
         format!(
-            "{}{}?{}",
+            "{}/{}?{}",
             base_url,
-            self.get_path(),
+            super::ACCOUNTS_PATH,
             self.get_query_parameters()
         )
     }
@@ -194,7 +190,10 @@ mod tests {
     #[test]
     fn test_accounts_request() {
         let request = AccountsRequest::new();
-        assert_eq!(request.get_path(), "/accounts");
+        assert_eq!(
+            request.build_url("https://horizon-testnet.stellar.org"),
+            "https://horizon-testnet.stellar.org/accounts?"
+        );
     }
 
     #[test]

--- a/src/accounts/accounts_request.rs
+++ b/src/accounts/accounts_request.rs
@@ -44,34 +44,34 @@ impl Request for AccountsRequest {
     }
 
     fn get_query_parameters(&self) -> String {
-        let mut query = String::new();
+        let mut query = vec![];
         if let Some(sponsor) = &self.sponsor {
-            query.push_str(&format!("sponsor={}&", sponsor));
+            query.push(format!("sponsor={}", sponsor));
         }
         if let Some(signer) = &self.signer {
-            query.push_str(&format!("signer={}&", signer));
+            query.push(format!("signer={}", signer));
         }
         if let Some(asset) = &self.asset {
-            query.push_str(&format!("asset={}&", asset));
+            query.push(format!("asset={}", asset));
         }
         if let Some(cursor) = &self.cursor {
-            query.push_str(&format!("cursor={}&", cursor));
+            query.push(format!("cursor={}", cursor));
         }
         if let Some(limit) = &self.limit {
-            query.push_str(&format!("limit={}&", limit));
+            query.push(format!("limit={}", limit));
         }
         if let Some(order) = &self.order {
-            query.push_str(&format!("order={}&", order));
+            query.push(format!("order={}", order));
         }
         if let Some(liquidity_pool) = &self.liquidity_pool {
-            query.push_str(&format!("liquidity_pool={}&", liquidity_pool));
+            query.push(format!("liquidity_pool={}", liquidity_pool));
         }
-        query.trim_end_matches('&').to_string()
+        format!("{}{}", match query.is_empty() {true => "", false => "?"}, query.join("&"))
     }
 
     fn build_url(&self, base_url: &str) -> String {
         format!(
-            "{}/{}?{}",
+            "{}/{}{}",
             base_url,
             super::ACCOUNTS_PATH,
             self.get_query_parameters()
@@ -192,7 +192,7 @@ mod tests {
         let request = AccountsRequest::new();
         assert_eq!(
             request.build_url("https://horizon-testnet.stellar.org"),
-            "https://horizon-testnet.stellar.org/accounts?"
+            "https://horizon-testnet.stellar.org/accounts"
         );
     }
 

--- a/src/accounts/mod.rs
+++ b/src/accounts/mod.rs
@@ -3,6 +3,8 @@ pub mod accounts_response;
 pub mod single_account_request;
 pub mod single_account_response;
 
+static ACCOUNTS_PATH: &str = "accounts";
+
 pub mod prelude {
     pub use super::accounts_request::*;
     pub use super::accounts_response::*;

--- a/src/accounts/single_account_request.rs
+++ b/src/accounts/single_account_request.rs
@@ -12,10 +12,6 @@ impl Request for SingleAccountRequest {
         SingleAccountRequest { account_id: None }
     }
 
-    fn get_path(&self) -> &str {
-        "/accounts/"
-    }
-
     fn get_query_parameters(&self) -> String {
         let mut query = String::new();
         if let Some(account_id) = &self.account_id {
@@ -27,9 +23,9 @@ impl Request for SingleAccountRequest {
 
     fn build_url(&self, base_url: &str) -> String {
         format!(
-            "{}{}{}",
+            "{}/{}/{}",
             base_url,
-            self.get_path(),
+            super::ACCOUNTS_PATH,
             self.get_query_parameters()
         )
     }

--- a/src/assets/all_assets_request.rs
+++ b/src/assets/all_assets_request.rs
@@ -1,5 +1,6 @@
-use crate::models::Request;
+use crate::{models::Request, BuildQueryParametersExt};
 use super::super::Order;
+
 
 
 // AllAssetsRequest is the request for the /assets endpoint
@@ -36,24 +37,13 @@ impl Request for AllAssetsRequest {
     }
 
     fn get_query_parameters(&self) -> String {
-        let mut query = vec![];
-        if let Some(asset_code) = &self.asset_code {
-            query.push(format!("asset_code={}", asset_code));
-        }
-        if let Some(asset_issuer) = &self.asset_issuer {
-            query.push(format!("asset_issuer={}", asset_issuer));
-        }
-        if let Some(cursor) = &self.cursor {
-            query.push(format!("cursor={}", cursor));
-        }
-        if let Some(limit) = &self.limit {
-            query.push(format!("limit={}", limit));
-        }
-        if let Some(order) = &self.order {
-            query.push(format!("order={}", order));
-        }
-
-        format!("{}{}", match query.is_empty() {true => "", false => "?"}, query.join("&"))
+        vec![
+            self.asset_code.as_ref().map(|ac| format!("asset_code={}", ac)),
+            self.asset_issuer.as_ref().map(|ai| format!("asset_issuer={}", ai)),
+            self.cursor.as_ref().map(|c| format!("cursor={}", c)),
+            self.limit.as_ref().map(|l| format!("limit={}", l)),
+            self.order.as_ref().map(|o| format!("order={}", o)),
+        ].build_query_parameters()
     }
 
     fn validate(&self) -> Result<(), String> {

--- a/src/assets/all_assets_request.rs
+++ b/src/assets/all_assets_request.rs
@@ -36,24 +36,24 @@ impl Request for AllAssetsRequest {
     }
 
     fn get_query_parameters(&self) -> String {
-        let mut query = String::new();
+        let mut query = vec![];
         if let Some(asset_code) = &self.asset_code {
-            query.push_str(&format!("asset_code={}&", asset_code));
+            query.push(format!("asset_code={}", asset_code));
         }
         if let Some(asset_issuer) = &self.asset_issuer {
-            query.push_str(&format!("asset_issuer={}&", asset_issuer));
+            query.push(format!("asset_issuer={}", asset_issuer));
         }
         if let Some(cursor) = &self.cursor {
-            query.push_str(&format!("cursor={}&", cursor));
+            query.push(format!("cursor={}", cursor));
         }
         if let Some(limit) = &self.limit {
-            query.push_str(&format!("limit={}&", limit));
+            query.push(format!("limit={}", limit));
         }
         if let Some(order) = &self.order {
-            query.push_str(&format!("order={}&", order));
+            query.push(format!("order={}", order));
         }
 
-        query.trim_end_matches('&').to_string()
+        format!("{}{}", match query.is_empty() {true => "", false => "?"}, query.join("&"))
     }
 
     fn validate(&self) -> Result<(), String> {
@@ -88,7 +88,7 @@ impl Request for AllAssetsRequest {
 
     fn build_url(&self, base_url: &str) -> String {
         format!(
-            "{}/{}?{}",
+            "{}/{}{}",
             base_url,
             super::ASSET_PATH,
             self.get_query_parameters()

--- a/src/assets/all_assets_request.rs
+++ b/src/assets/all_assets_request.rs
@@ -1,6 +1,6 @@
 use crate::models::Request;
-
 use super::super::Order;
+
 
 // AllAssetsRequest is the request for the /assets endpoint
 // [More Details] https://www.stellar.org/developers/horizon/reference/endpoints/assets-all.html "Assets"
@@ -33,10 +33,6 @@ impl Request for AllAssetsRequest {
             limit: None,
             order: None,
         }
-    }
-
-    fn get_path(&self) -> &str {
-        "/assets"
     }
 
     fn get_query_parameters(&self) -> String {
@@ -92,9 +88,9 @@ impl Request for AllAssetsRequest {
 
     fn build_url(&self, base_url: &str) -> String {
         format!(
-            "{}{}?{}",
+            "{}/{}?{}",
             base_url,
-            self.get_path(),
+            super::ASSET_PATH,
             self.get_query_parameters()
         )
     }

--- a/src/assets/mod.rs
+++ b/src/assets/mod.rs
@@ -1,6 +1,8 @@
 pub mod all_assets_request;
 pub mod all_assets_response;
 
+static ASSET_PATH: &str = "assets";
+
 pub mod prelude {
     pub use super::all_assets_request::*;
     pub use super::all_assets_response::*;

--- a/src/claimable_balances/all_claimable_balances_request.rs
+++ b/src/claimable_balances/all_claimable_balances_request.rs
@@ -40,10 +40,6 @@ impl Request for AllClaimableBalancesRequest {
         }
     }
 
-    fn get_path(&self) -> &str {
-        "/claimable_balances/"
-    }
-
     fn get_query_parameters(&self) -> String {
         let mut query = String::new();
         if let Some(sponsor) = &self.sponsor {
@@ -70,9 +66,9 @@ impl Request for AllClaimableBalancesRequest {
 
     fn build_url(&self, base_url: &str) -> String {
         format!(
-            "{}{}?{}",
+            "{}/{}/?{}",
             base_url,
-            self.get_path(),
+            super::CLAIMABLE_BALANCES_PATH,            
             self.get_query_parameters()
         )
     }

--- a/src/claimable_balances/all_claimable_balances_request.rs
+++ b/src/claimable_balances/all_claimable_balances_request.rs
@@ -41,32 +41,32 @@ impl Request for AllClaimableBalancesRequest {
     }
 
     fn get_query_parameters(&self) -> String {
-        let mut query = String::new();
+        let mut query = vec![];
         if let Some(sponsor) = &self.sponsor {
-            query.push_str(&format!("sponsor={}&", sponsor));
+            query.push(format!("sponsor={}", sponsor));
         }
         if let Some(asset) = &self.asset {
-            query.push_str(&format!("asset={}&", asset));
+            query.push(format!("asset={}", asset));
         }
         if let Some(claimant) = &self.claimant {
-            query.push_str(&format!("claimant={}&", claimant));
+            query.push(format!("claimant={}", claimant));
         }
         if let Some(cursor) = &self.cursor {
-            query.push_str(&format!("cursor={}&", cursor));
+            query.push(format!("cursor={}", cursor));
         }
         if let Some(limit) = &self.limit {
-            query.push_str(&format!("limit={}&", limit));
+            query.push(format!("limit={}", limit));
         }
         if let Some(order) = &self.order {
-            query.push_str(&format!("order={}&", order));
+            query.push(format!("order={}", order));
         }
 
-        query.trim_end_matches('&').to_string()
+        format!("{}{}", match query.is_empty() {true => "", false => "?"}, query.join("&"))
     }
 
     fn build_url(&self, base_url: &str) -> String {
         format!(
-            "{}/{}/?{}",
+            "{}/{}/{}",
             base_url,
             super::CLAIMABLE_BALANCES_PATH,            
             self.get_query_parameters()

--- a/src/claimable_balances/all_claimable_balances_request.rs
+++ b/src/claimable_balances/all_claimable_balances_request.rs
@@ -1,4 +1,4 @@
-use crate::models::*;
+use crate::{BuildQueryParametersExt, models::*};
 
 use super::super::Order;
 use super::super::AssetType;
@@ -41,27 +41,14 @@ impl Request for AllClaimableBalancesRequest {
     }
 
     fn get_query_parameters(&self) -> String {
-        let mut query = vec![];
-        if let Some(sponsor) = &self.sponsor {
-            query.push(format!("sponsor={}", sponsor));
-        }
-        if let Some(asset) = &self.asset {
-            query.push(format!("asset={}", asset));
-        }
-        if let Some(claimant) = &self.claimant {
-            query.push(format!("claimant={}", claimant));
-        }
-        if let Some(cursor) = &self.cursor {
-            query.push(format!("cursor={}", cursor));
-        }
-        if let Some(limit) = &self.limit {
-            query.push(format!("limit={}", limit));
-        }
-        if let Some(order) = &self.order {
-            query.push(format!("order={}", order));
-        }
-
-        format!("{}{}", match query.is_empty() {true => "", false => "?"}, query.join("&"))
+        vec![
+            self.sponsor.as_ref().map(|s| format!("sponsor={}", s)),
+            self.asset.as_ref().map(|a| format!("asset={}", a)),
+            self.claimant.as_ref().map(|c| format!("claimant={}", c)),
+            self.cursor.as_ref().map(|c| format!("cursor={}", c)),
+            self.limit.as_ref().map(|l| format!("limit={}", l)),
+            self.order.as_ref().map(|o| format!("order={}", o)),
+        ].build_query_parameters()
     }
 
     fn build_url(&self, base_url: &str) -> String {

--- a/src/claimable_balances/mod.rs
+++ b/src/claimable_balances/mod.rs
@@ -3,6 +3,8 @@ pub mod all_claimable_balances_response;
 pub mod single_claimable_balance_request;
 pub mod single_claimable_balance_response;
 
+static CLAIMABLE_BALANCES_PATH: &str = "claimable_balances";
+
 pub mod prelude {
     pub use super::all_claimable_balances_request::*;
     pub use super::all_claimable_balances_response::*;

--- a/src/claimable_balances/single_claimable_balance_request.rs
+++ b/src/claimable_balances/single_claimable_balance_request.rs
@@ -16,10 +16,6 @@ impl Request for SingleClaimableBalanceRequest {
         }
     }
 
-    fn get_path(&self) -> &str {
-        "/claimable_balances/"
-    }
-
     fn get_query_parameters(&self) -> String {
         let mut query = String::new();
         if let Some(claimable_balance_id) = &self.claimable_balance_id {
@@ -30,9 +26,9 @@ impl Request for SingleClaimableBalanceRequest {
 
     fn build_url(&self, base_url: &str) -> String {
         format!(
-            "{}{}{}",
+            "{}/{}/{}",
             base_url,
-            self.get_path(),
+            super::CLAIMABLE_BALANCES_PATH,            
             self.get_query_parameters()
         )
     }

--- a/src/claimable_balances/single_claimable_balance_request.rs
+++ b/src/claimable_balances/single_claimable_balance_request.rs
@@ -21,12 +21,12 @@ impl Request for SingleClaimableBalanceRequest {
         if let Some(claimable_balance_id) = &self.claimable_balance_id {
             query.push_str(&format!("{}", claimable_balance_id));
         }
-        query
+        format!("/{}", query)
     }
 
     fn build_url(&self, base_url: &str) -> String {
         format!(
-            "{}/{}/{}",
+            "{}/{}{}",
             base_url,
             super::CLAIMABLE_BALANCES_PATH,            
             self.get_query_parameters()

--- a/src/ledgers/ledgers_request.rs
+++ b/src/ledgers/ledgers_request.rs
@@ -21,21 +21,21 @@ impl Request for LedgersRequest {
     }
 
     fn get_query_parameters(&self) -> String {
-        let mut query_parameters = vec![];
+        let mut query = vec![];
 
         if let Some(cursor) = &self.cursor {
-            query_parameters.push(format!("cursor={}", cursor));
+            query.push(format!("cursor={}", cursor));
         }
 
         if let Some(limit) = &self.limit {
-            query_parameters.push(format!("limit={}", limit));
+            query.push(format!("limit={}", limit));
         }
 
         if let Some(order) = &self.order {
-            query_parameters.push(format!("order={}", order));
+            query.push(format!("order={}", order));
         }
 
-        query_parameters.join("&")
+        format!("{}{}", match query.is_empty() {true => "", false => "?"}, query.join("&"))
     }
 
     fn validate(&self) -> Result<(), String> {
@@ -59,7 +59,7 @@ impl Request for LedgersRequest {
 
     fn build_url(&self, base_url: &str) -> String {
         format!(
-            "{}/{}?{}",
+            "{}/{}{}",
             base_url,
             super::LEDGERS_PATH,
             self.get_query_parameters()
@@ -107,7 +107,7 @@ mod tests {
         let request = LedgersRequest::new();
         assert_eq!(
             request.build_url("https://horizon-testnet.stellar.org"),
-            "https://horizon-testnet.stellar.org/ledgers?"
+            "https://horizon-testnet.stellar.org/ledgers"
         );
     }
 }

--- a/src/ledgers/ledgers_request.rs
+++ b/src/ledgers/ledgers_request.rs
@@ -20,10 +20,6 @@ impl Request for LedgersRequest {
         }
     }
 
-    fn get_path(&self) -> &str {
-        "/ledgers"
-    }
-
     fn get_query_parameters(&self) -> String {
         let mut query_parameters = vec![];
 
@@ -63,9 +59,9 @@ impl Request for LedgersRequest {
 
     fn build_url(&self, base_url: &str) -> String {
         format!(
-            "{}{}?{}",
+            "{}/{}?{}",
             base_url,
-            self.get_path(),
+            super::LEDGERS_PATH,
             self.get_query_parameters()
         )
     }
@@ -109,7 +105,9 @@ mod tests {
     #[test]
     fn test_ledgers_request() {
         let request = LedgersRequest::new();
-
-        assert_eq!(request.get_path(), "/ledgers");
+        assert_eq!(
+            request.build_url("https://horizon-testnet.stellar.org"),
+            "https://horizon-testnet.stellar.org/ledgers?"
+        );
     }
 }

--- a/src/ledgers/ledgers_request.rs
+++ b/src/ledgers/ledgers_request.rs
@@ -1,4 +1,4 @@
-use crate::models::*;
+use crate::{BuildQueryParametersExt, models::*};
 
 use super::super::Order;
 
@@ -21,21 +21,11 @@ impl Request for LedgersRequest {
     }
 
     fn get_query_parameters(&self) -> String {
-        let mut query = vec![];
-
-        if let Some(cursor) = &self.cursor {
-            query.push(format!("cursor={}", cursor));
-        }
-
-        if let Some(limit) = &self.limit {
-            query.push(format!("limit={}", limit));
-        }
-
-        if let Some(order) = &self.order {
-            query.push(format!("order={}", order));
-        }
-
-        format!("{}{}", match query.is_empty() {true => "", false => "?"}, query.join("&"))
+        vec![
+            self.cursor.as_ref().map(|c| format!("cursor={}", c)),
+            self.limit.as_ref().map(|l| format!("limit={}", l)),
+            self.order.as_ref().map(|o| format!("order={}", o)),
+        ].build_query_parameters()
     }
 
     fn validate(&self) -> Result<(), String> {

--- a/src/ledgers/mod.rs
+++ b/src/ledgers/mod.rs
@@ -3,6 +3,8 @@ pub mod ledgers_response;
 pub mod single_ledger_request;
 pub mod single_ledger_response;
 
+static LEDGERS_PATH: &str = "ledgers";
+
 pub mod prelude {
     pub use super::ledgers_request::*;
     pub use super::ledgers_response::*;

--- a/src/ledgers/single_ledger_request.rs
+++ b/src/ledgers/single_ledger_request.rs
@@ -11,7 +11,7 @@ impl Request for SingleLedgerRequest {
     }
 
     fn get_query_parameters(&self) -> String {
-        format!("{}", self.sequence)
+        format!("/{}", self.sequence)
     }
 
     fn validate(&self) -> Result<(), String> {
@@ -24,7 +24,7 @@ impl Request for SingleLedgerRequest {
 
     fn build_url(&self, base_url: &str) -> String {
         format!(
-            "{}/{}/{}",
+            "{}/{}{}",
             base_url,
             super::LEDGERS_PATH,
             self.get_query_parameters()

--- a/src/ledgers/single_ledger_request.rs
+++ b/src/ledgers/single_ledger_request.rs
@@ -10,10 +10,6 @@ impl Request for SingleLedgerRequest {
         Self { sequence: 0 }
     }
 
-    fn get_path(&self) -> &str {
-        "/ledgers"
-    }
-
     fn get_query_parameters(&self) -> String {
         format!("{}", self.sequence)
     }
@@ -28,9 +24,9 @@ impl Request for SingleLedgerRequest {
 
     fn build_url(&self, base_url: &str) -> String {
         format!(
-            "{}{}/{}",
+            "{}/{}/{}",
             base_url,
-            self.get_path(),
+            super::LEDGERS_PATH,
             self.get_query_parameters()
         )
     }
@@ -56,7 +52,6 @@ mod tests {
     #[test]
     fn test_ledgers_request() {
         let request = SingleLedgerRequest::new();
-
-        assert_eq!(request.get_path(), "/ledgers");
+        assert_eq!(request.build_url("https://horizon-testnet.stellar.org"), "https://horizon-testnet.stellar.org/ledgers/0");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,3 +129,17 @@ impl std::fmt::Display for Order {
         }
     }
 }
+
+trait BuildQueryParametersExt<T> {
+    fn build_query_parameters(self) -> String;
+}
+
+impl<T: ToString> BuildQueryParametersExt<Option<T>> for Vec<Option<T>> {
+    fn build_query_parameters(self) -> String {
+        let params = self.into_iter().filter_map(|x| x.map(|val| val.to_string())).collect::<Vec<String>>().join("&");
+        match params.is_empty() {
+            true => "".to_string(),
+            false => format!("?{}", params),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,10 @@ trait BuildQueryParametersExt<T> {
 
 impl<T: ToString> BuildQueryParametersExt<Option<T>> for Vec<Option<T>> {
     fn build_query_parameters(self) -> String {
-        let params = self.into_iter().filter_map(|x| x.map(|val| val.to_string())).collect::<Vec<String>>().join("&");
+        let params = self.into_iter()
+            // The filter_map function filters out the None values, leaving only the Some values with formatted strings.
+            .filter_map(|x| x.map(|val| val.to_string()))
+            .collect::<Vec<String>>().join("&");
         match params.is_empty() {
             true => "".to_string(),
             false => format!("?{}", params),

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -7,13 +7,6 @@ pub trait Request {
     /// [Request](trait.Request.html)
     fn new() -> Self;
 
-    /// Gets the relative URL for the request
-    /// # Arguments
-    /// * `self` - The request object
-    /// # Returns
-    /// The relative URL for the request
-    fn get_path(&self) -> &str;
-
     /// Gets the query parameters for the request
     /// # Arguments
     /// * `self` - The request object


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Code refactoring

### :arrow_heading_down: What is the current behavior?
Currently, there a a `get_path` method added to the `Request` trait, which is only used internally within the request to get the path. This path is often shared between multiple requests sharing the same controller. I think this is a wrong design, and doesn't allow for a proper re-use of path strings, which we should define one, and use as a const value.

### :new: What is the new behavior (if this is a feature change)?
The paths for a particular module are not defined as `const` values, and can be re-used for multiple request reaching out to the same endpoint. 

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
The unit-tests still cover the logic.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current main
