### PR TITLE
Add effects-for-ledger endpoint

### DIFF
--- a/src/effects/all_effects_request.rs
+++ b/src/effects/all_effects_request.rs
@@ -111,3 +111,29 @@ impl Request for AllEffectsRequest {
         )
     }
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_all_effects_request_set_limit() {
+        let invalid_limit: u8 = 255;
+
+        let request = AllEffectsRequest::new()
+            .set_limit(invalid_limit);
+
+        assert!(request.is_err());
+    }
+
+    #[test]
+    fn test_all_effects_request_set_cursor() {
+        let invalid_cursor = 0;
+
+        let request = AllEffectsRequest::new()
+            .set_cursor(invalid_cursor);
+
+        assert!(request.is_err());
+    }
+}

--- a/src/effects/effects_for_ledger_request.rs
+++ b/src/effects/effects_for_ledger_request.rs
@@ -1,9 +1,27 @@
 use crate::{models::{Order, Request}, BuildQueryParametersExt};
 
+/// Represents a request to fetch effects associated with a specific ledger from the Stellar Horizon API.
+///
+/// `EffectsForLedgerRequest` is a struct designed to facilitate the retrieval of effects for a given ledger sequence.
+/// It supports pagination, custom limits, and sorting order through its fields, allowing for flexible and efficient
+/// data access patterns.
+///
+/// # Example
+/// ```rust
+/// use stellar_rs::effects::effects_for_ledger_request::EffectsForLedgerRequest;
+/// use stellar_rs::models::Order;
+///
+/// let mut request = EffectsForLedgerRequest::new()
+///     .set_sequence(125)
+///     .set_limit(2);
+///
+/// // The request is now ready to be used with a Horizon client to fetch effects for the specified ledger.
+/// ```
+///
 #[derive(Default)]
-pub struct EffectsForAccountRequest {
-    /// The accounts public id
-    account_id: Option<String>,
+pub struct EffectsForLedgerRequest {
+    /// The ledger's sequence number for which effects are to be retrieved.
+    sequence: Option<u32>,
 
     /// A pointer to a specific location in a collection of responses, derived from the
     ///   `paging_token` value of a record. Used for pagination control in the API response.
@@ -18,20 +36,20 @@ pub struct EffectsForAccountRequest {
     order: Option<Order>,
 }
 
-impl EffectsForAccountRequest {
+impl EffectsForLedgerRequest {
     /// Creates a new `LedgersRequest` with default parameters.
     pub fn new() -> Self {
-        EffectsForAccountRequest::default()
+        EffectsForLedgerRequest::default()
     }
 
-    /// Sets the account id for the request.
+    /// Sets the ledger sequence for the request.
     /// 
     /// # Arguments
-    /// * `account_id` - A `String` value representing the account id.
+    /// * `sequence` - A `String` value representing the ledger sequence.
     /// 
-    pub fn set_account_id(self, account_id: String) -> EffectsForAccountRequest {
-        EffectsForAccountRequest {
-            account_id: Some(account_id),
+    pub fn set_sequence(self, sequence: u32) -> EffectsForLedgerRequest {
+        EffectsForLedgerRequest {
+            sequence: Some(sequence),
             ..self
         }
     }
@@ -41,12 +59,12 @@ impl EffectsForAccountRequest {
     /// # Arguments
     /// * `cursor` - A `u32` value pointing to a specific location in a collection of responses.
     ///
-    pub fn set_cursor(self, cursor: u32) -> Result<EffectsForAccountRequest, String> {
+    pub fn set_cursor(self, cursor: u32) -> Result<EffectsForLedgerRequest, String> {
         if cursor < 1 {
             return Err("cursor must be greater than or equal to 1".to_string());
         }
 
-        Ok(EffectsForAccountRequest {
+        Ok(EffectsForLedgerRequest {
             cursor: Some(cursor),
             ..self
         })
@@ -57,12 +75,12 @@ impl EffectsForAccountRequest {
     /// # Arguments
     /// * `limit` - A `u8` value specifying the maximum number of records. Range: 1 to 200. Defaults to 10.
     ///
-    pub fn set_limit(self, limit: u8) -> Result<EffectsForAccountRequest, String> {
+    pub fn set_limit(self, limit: u8) -> Result<EffectsForLedgerRequest, String> {
         if limit < 1 || limit > 200 {
             return Err("limit must be between 1 and 200".to_string());
         }
 
-        Ok(EffectsForAccountRequest {
+        Ok(EffectsForLedgerRequest {
             limit: Some(limit),
             ..self
         })
@@ -73,18 +91,17 @@ impl EffectsForAccountRequest {
     /// # Arguments
     /// * `order` - An [`Order`] enum value specifying the order (ascending or descending).
     ///
-    pub fn set_order(self, order: Order) -> EffectsForAccountRequest {
-        EffectsForAccountRequest {
+    pub fn set_order(self, order: Order) -> EffectsForLedgerRequest {
+        EffectsForLedgerRequest {
             order: Some(order),
             ..self
         }
     }
 }
 
-impl Request for EffectsForAccountRequest {
+impl Request for EffectsForLedgerRequest {
     fn get_query_parameters(&self) -> String {
         vec![
-            self.account_id.as_ref().map(|a| format!("account={}", a)),
             self.cursor.as_ref().map(|c| format!("cursor={}", c)),
             self.limit.as_ref().map(|l| format!("limit={}", l)),
             self.order.as_ref().map(|o| format!("order={}", o)),
@@ -93,43 +110,54 @@ impl Request for EffectsForAccountRequest {
     }
 
     fn build_url(&self, base_url: &str) -> String {
+        // Extract the sequence as a string if set
+        let seq = self.sequence.as_ref().map_or(String::new(), |s| s.to_string());
+
         format!(
-            "{}/{}{}",
+            "{}/ledgers/{}/{}{}",
             base_url,
+            seq,
             super::EFFECTS_PATH,
             self.get_query_parameters()
         )
     }
 }
 
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_effects_for_account_request() {
-        let request = EffectsForAccountRequest::new();
+    fn test_effects_for_ledger_request_build_url() {
+        let sequence: u32 = 125;
+
+        let request = EffectsForLedgerRequest::new()
+            .set_sequence(sequence);
+
+        let url = request.build_url("https://horizon-testnet.stellar.org");
+
         assert_eq!(
-            request.build_url("https://horizon-testnet.stellar.org"),
-            "https://horizon-testnet.stellar.org/effects"
+            url,
+            format!("https://horizon-testnet.stellar.org/ledgers/{}/{}", sequence, crate::effects::EFFECTS_PATH)
         );
     }
-    
+
     #[test]
-    fn test_effects_for_account_request_set_limit() {
+    fn test_effects_for_ledger_request_set_limit() {
         let invalid_limit: u8 = 255;
 
-        let request = EffectsForAccountRequest::new()
+        let request = EffectsForLedgerRequest::new()
             .set_limit(invalid_limit);
 
         assert!(request.is_err());
     }
 
     #[test]
-    fn test_effects_for_account_request_set_cursor() {
+    fn test_effects_for_ledger_request_set_cursor() {
         let invalid_cursor = 0;
 
-        let request = EffectsForAccountRequest::new()
+        let request = EffectsForLedgerRequest::new()
             .set_cursor(invalid_cursor);
 
         assert!(request.is_err());

--- a/src/effects/effects_response.rs
+++ b/src/effects/effects_response.rs
@@ -9,7 +9,7 @@ use crate::models::Response;
 /// providing quick navigation across different pages of the effect response.
 ///
 #[derive(Debug, Deserialize, Clone, Getters)]
-pub struct AllEffectsResponseLink {
+pub struct EffectsResponseLink {
     /// The link to the current page of the effect response.
     #[serde(rename = "self")]
     self_link: SelfLink,
@@ -38,7 +38,7 @@ pub struct SelfLink {
 /// providing quick navigation across operational sequence belonging to the effect.
 ///
 #[derive(Debug, Deserialize, Clone, Getters)]
-pub struct AllEffectsResponseRecordLink {
+pub struct EffectsResponseRecordLink {
     /// The link to the current operation of the effect.
     operation: SelfLink,
     /// The link to the effect succeeding the current operation of the effect.
@@ -55,7 +55,7 @@ pub struct AllEffectsResponseRecordLink {
 #[derive(Debug, Deserialize, Clone, Getters)]
 pub struct Record {
     /// Navigational links related to the operation of the effect.
-    pub _links: AllEffectsResponseRecordLink,
+    pub _links: EffectsResponseRecordLink,
     /// The unique identifier of the account.
     pub id: String,
     /// A token used for paging through results.
@@ -95,14 +95,14 @@ pub struct Embedded {
 /// navigational links and a collection of effect records, each with comprehensive details about the effect.
 ///
 #[derive(Debug, Deserialize, Clone, Getters)]
-pub struct AllEffectsResponse {
+pub struct EffectsResponse {
     /// Navigational links for the current, next, and previous pages of the response.
-    _links: AllEffectsResponseLink,
+    _links: EffectsResponseLink,
     /// Contains the actual list of effect records in the `records` field.
     _embedded: Embedded,
 }
 
-impl Response for AllEffectsResponse {
+impl Response for EffectsResponse {
     fn from_json(json: String) -> Result<Self, String> {
         serde_json::from_str(&json).map_err(|e| e.to_string())
     }

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -1,23 +1,15 @@
 pub mod all_effects_request;
-pub mod all_effects_response;
+pub mod effects_response;
 pub mod effects_for_account_request;
 pub mod effects_for_account_response;
+pub mod effects_for_ledger_request;
 
 static EFFECTS_PATH: &str = "effects";
 
 pub mod prelude {
     pub use super::all_effects_request::*;
-    pub use super::all_effects_response::*;
+    pub use super::effects_response::*;
     pub use super::effects_for_account_request::*;
     pub use super::effects_for_account_response::*;
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn dummy_test() {
-        assert_eq!(EFFECTS_PATH, "effects");
-    }
+    pub use super::effects_for_ledger_request::*;
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
* Adds effects for ledger endpoint
* Creates a single effects_response used by all-effects and effects-for-ledger since they're the same anyway. In the future, we might also add effects-for-accounts and other endpoints in this family with the same response.

### :bug: Recommendations for testing
Tests the endpoint by adding a ledger sequence to make sure the URL is built right.
Please note that the ledger sequence is part of the URL when added, instead of being part of the query parameters.

### :memo: Links to relevant issues/docs
Please note that the documentation at this time is incomplete.
This is by design, because the way things are implemented is continuously changing as we implement this family of endpoints. By the end, all documentation will be updated.