### PR TITLE
All Offers Endpoint

### DIFF
--- a/stellar_rust_sdk/src/horizon_client.rs
+++ b/stellar_rust_sdk/src/horizon_client.rs
@@ -866,6 +866,8 @@ impl HorizonClient {
     /// # use stellar_rs::offers::prelude::*;
     /// # use stellar_rs::models::Request;
     /// # use stellar_rs::horizon_client::HorizonClient;
+    /// # use stellar_rust_sdk_derive::Pagination;
+    /// # use stellar_rs::Paginatable;
     /// #
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();

--- a/stellar_rust_sdk/src/horizon_client.rs
+++ b/stellar_rust_sdk/src/horizon_client.rs
@@ -840,8 +840,58 @@ impl HorizonClient {
     pub async fn get_single_offer(
         &self,
         request: &SingleOfferRequest<OfferId>,
-    ) -> Result<SingleOfferResponse, String> {
-        self.get::<SingleOfferResponse>(request).await
+    ) -> Result<OfferResponse, String> {
+        self.get::<OfferResponse>(request).await
+    }
+
+    /// Retrieves a list of all offers from the Horizon server.
+    ///
+    /// This asynchronous method fetches a list of all offers from the Horizon server.
+    /// It requires an [`AllOffersRequest`] to specify the optional query parameters.
+    ///
+    /// # Arguments
+    /// * `request` - A reference to an [`AllOffersRequest`] instance, containing the
+    /// parameters for the offers request.
+    ///
+    /// # Returns
+    ///
+    /// On successful execution, returns a `Result` containing an [`OfferResponse`], which includes
+    /// the list of all offers obtained from the Horizon server. If the request fails, it returns an error within `Result`.
+    ///
+    /// # Usage
+    /// To use this method, create an instance of [`AllOffersRequest`] and set any desired
+    /// filters or parameters.
+    ///
+    /// ```
+    /// # use stellar_rs::offers::prelude::*;
+    /// # use stellar_rs::models::Request;
+    /// # use stellar_rs::horizon_client::HorizonClient;
+    /// #
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
+    /// # let horizon_client = HorizonClient::new(base_url)
+    /// #    .expect("Failed to create Horizon Client");
+    /// let request = AllOffersRequest::new()
+    ///   .set_limit(2).unwrap();
+    ///
+    /// let response = horizon_client.get_all_offers(&request).await;
+    ///
+    /// // Access the offers
+    /// if let Ok(offers_response) = response {
+    ///     for offer in offers_response.embedded().records() {
+    ///         println!("Offer ID: {}", offer.id());
+    ///         // Further processing...
+    ///     }
+    /// }
+    /// # Ok({})
+    /// # }
+    /// ```
+    ///
+    pub async fn get_all_offers(
+        &self,
+        request: &AllOffersRequest,
+    ) -> Result<AllOffersResponse, String> {
+        self.get::<AllOffersResponse>(request).await
     }
 
     /// Retrieves a list of all operations from the Horizon server.

--- a/stellar_rust_sdk/src/offers/all_offers_request.rs
+++ b/stellar_rust_sdk/src/offers/all_offers_request.rs
@@ -35,23 +35,28 @@ use crate::Paginatable;
 ///
 #[derive(Default, Pagination)]
 pub struct AllOffersRequest {
+    /// Optional. The ID of the sponsor. When set, the response will
+    /// only include offers sponsored by the specified account.
     sponsor: Option<String>,
+    /// Optional. The ID of the seller making the offer. When set, the response will
+    /// only include offers created by by the specified account.
     seller: Option<String>,
-    
+    /// Optional. Indicates an selling asset for which offers are being queried.
+    /// When set, the response will filter the offers that hold this specific asset.
     // TODO: Make `NativeAsset` also possible
     selling: Option<Asset<IssuedAsset>>,
+    /// Optional. Indicates a buying asset for which offers are being queried.
+    /// When set, the response will filter the offers that hold this specific asset.
+    // TODO: Make `NativeAsset` also possible
     buying: Option<Asset<IssuedAsset>>,
-
     /// A pointer to a specific location in a collection of responses, derived from the
-    ///   `paging_token` value of a record. Used for pagination control in the API response.
+    /// `paging_token` value of a record. Used for pagination control in the API response.
     cursor: Option<u32>,
-
     /// Specifies the maximum number of records to be returned in a single response.
-    ///   The range for this parameter is from 1 to 200. The default value is set to 10.
+    /// The range for this parameter is from 1 to 200. The default value is set to 10.
     limit: Option<u8>,
-
     /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    ///   and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
+    /// and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
     order: Option<Order>,
 }
 
@@ -80,10 +85,16 @@ impl Request for AllOffersRequest {
 }
 
 impl AllOffersRequest {
+    /// Creates a new `AllOffersRequest` with default parameters.
     pub fn new() -> Self {
         AllOffersRequest::default()
     }
 
+    /// Specifies the sponsor's public key in the request.
+    ///
+    /// # Arguments
+    /// * `sponsor` - A Stellar public key of the sponsor to filter offers by.
+    ///
     pub fn set_sponsor(self, sponsor: String) -> Result<AllOffersRequest, String> {
         if let Err(e) = is_public_key(&sponsor) {
             return Err(e.to_string());
@@ -95,6 +106,11 @@ impl AllOffersRequest {
         })
     }
 
+    /// Specifies the seller's public key in the request.
+    ///
+    /// # Arguments
+    /// * `seller` - A Stellar public key of the seller to filter offers by.
+    ///
     pub fn set_seller(self, seller: String) -> Result<AllOffersRequest, String> {
         if let Err(e) = is_public_key(&seller) {
             return Err(e.to_string());
@@ -106,6 +122,11 @@ impl AllOffersRequest {
         })
     }
 
+    /// Specifies the selling asset in the request.
+    ///
+    /// # Arguments
+    /// * `selling` - The selling asset to filter offers by.
+    ///
     pub fn set_selling(self, selling: Asset<IssuedAsset>) -> AllOffersRequest {
         AllOffersRequest {
             selling: Some(selling),
@@ -113,6 +134,11 @@ impl AllOffersRequest {
         }
     }
 
+    /// Specifies the buying asset in the request.
+    ///
+    /// # Arguments
+    /// * `buying` - The buying asset to filter offers by.
+    ///
     pub fn set_buying(self, buying: Asset<IssuedAsset>) -> AllOffersRequest {
         AllOffersRequest {
             buying: Some(buying),

--- a/stellar_rust_sdk/src/offers/all_offers_request.rs
+++ b/stellar_rust_sdk/src/offers/all_offers_request.rs
@@ -1,0 +1,166 @@
+use crate::{models::*, BuildQueryParametersExt};
+
+use stellar_rust_sdk_derive::Pagination;
+use crate::Paginatable;
+
+/// Represents a request to list all offers from the Stellar Horizon API.
+///
+/// This structure is used to construct a query to retrieve a comprehensive list of offers, which
+/// can be filtered by sponsor, seller, selling asset and buying asset. It adheres to the structure and parameters required
+/// by the Horizon API for retrieving a
+/// <a href="https://developers.stellar.org/network/horizon/api-reference/resources/get-all-offers">list of all offers</a>.
+///
+/// # Usage
+///
+/// Create an instance of this struct and set the desired query parameters to filter the list of offers.
+/// Pass this request object to the [`HorizonClient::get_all_offers`](crate::horizon_client::HorizonClient::get_all_offers)
+/// method to fetch the corresponding data from the Horizon API.
+///
+/// # Example
+/// ```
+/// use stellar_rs::offers::all_offers_request::AllOffersRequest;
+/// use stellar_rs::models::{Asset, NativeAsset, Order};
+///
+/// let request = AllOffersRequest::new()
+///     .set_sponsor("GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5".to_string()).unwrap() // Optional sponsor filter
+///     .set_seller("GDQJUTQYK2MQX2VGDR2FYWLIYAQIEGXTQVTFEMGH2BEWFG4BRUY4CKI7".to_string()).unwrap() // Optional seller filter
+///     .set_selling(Asset::new().set_issued("USD", "GDQJUTQYK2MQX2VGDR2FYWLIYAQIEGXTQVTFEMGH2BEWFG4BRUY4CKI7").unwrap()) // Optional selling asset filter
+///     .set_buying(Asset::new().set_issued("USD", "GDQJUTQYK2MQX2VGDR2FYWLIYAQIEGXTQVTFEMGH2BEWFG4BRUY4CKI7").unwrap()) // Optional buying asset filter
+///     .set_cursor(123).unwrap() // Optional cursor for pagination
+///     .set_limit(100).unwrap() // Optional limit for response records
+///     .set_order(Order::Desc); // Optional order of records
+///
+/// // Use with HorizonClient::get_all_offers
+/// ```
+///
+#[derive(Default, Pagination)]
+pub struct AllOffersRequest {
+    sponsor: Option<String>,
+    seller: Option<String>,
+    
+    // TODO: Make `NativeAsset` also possible
+    selling: Option<Asset<IssuedAsset>>,
+    buying: Option<Asset<IssuedAsset>>,
+
+    /// A pointer to a specific location in a collection of responses, derived from the
+    ///   `paging_token` value of a record. Used for pagination control in the API response.
+    cursor: Option<u32>,
+
+    /// Specifies the maximum number of records to be returned in a single response.
+    ///   The range for this parameter is from 1 to 200. The default value is set to 10.
+    limit: Option<u8>,
+
+    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
+    ///   and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
+    order: Option<Order>,
+}
+
+impl Request for AllOffersRequest {
+    fn get_query_parameters(&self) -> String {
+        vec![
+            self.sponsor.as_ref().map(|s| format!("sponsor={}", s)),
+            self.seller.as_ref().map(|s| format!("seller={}", s)),
+            self.selling.as_ref().map(|s| format!("selling={}", s)),
+            self.buying.as_ref().map(|b| format!("buying={}", b)),
+            self.cursor.as_ref().map(|c| format!("cursor={}", c)),
+            self.limit.as_ref().map(|l| format!("limit={}", l)),
+            self.order.as_ref().map(|o| format!("order={}", o)),
+        ]
+        .build_query_parameters()
+    }
+
+    fn build_url(&self, base_url: &str) -> String {
+        format!(
+            "{}/{}/{}",
+            base_url,
+            super::OFFERS_PATH,
+            self.get_query_parameters()
+        )
+    }
+}
+
+impl AllOffersRequest {
+    pub fn new() -> Self {
+        AllOffersRequest::default()
+    }
+
+    pub fn set_sponsor(self, sponsor: String) -> Result<AllOffersRequest, String> {
+        if let Err(e) = is_public_key(&sponsor) {
+            return Err(e.to_string());
+        }
+
+        Ok(AllOffersRequest {
+            sponsor: Some(sponsor),
+            ..self
+        })
+    }
+
+    pub fn set_seller(self, seller: String) -> Result<AllOffersRequest, String> {
+        if let Err(e) = is_public_key(&seller) {
+            return Err(e.to_string());
+        }
+
+        Ok(AllOffersRequest {
+            seller: Some(seller),
+            ..self
+        })
+    }
+
+    pub fn set_selling(self, selling: Asset<IssuedAsset>) -> AllOffersRequest {
+        AllOffersRequest {
+            selling: Some(selling),
+            ..self
+        }
+    }
+
+    pub fn set_buying(self, buying: Asset<IssuedAsset>) -> AllOffersRequest {
+        AllOffersRequest {
+            buying: Some(buying),
+            ..self
+        }
+    }
+
+    /// Sets the cursor for pagination.
+    ///
+    /// # Arguments
+    /// * `cursor` - A `u32` value pointing to a specific location in a collection of responses.
+    ///
+    pub fn set_cursor(self, cursor: u32) -> Result<AllOffersRequest, String> {
+        if cursor < 1 {
+            return Err("cursor must be greater than or equal to 1".to_string());
+        }
+
+        Ok(AllOffersRequest {
+            cursor: Some(cursor),
+            ..self
+        })
+    }
+
+    /// Sets the maximum number of records to return.
+    ///
+    /// # Arguments
+    /// * `limit` - A `u8` value specifying the maximum number of records. Range: 1 to 200. Defaults to 10.
+    ///
+    pub fn set_limit(self, limit: u8) -> Result<AllOffersRequest, String> {
+        if limit < 1 || limit > 200 {
+            return Err("limit must be between 1 and 200".to_string());
+        }
+
+        Ok(AllOffersRequest {
+            limit: Some(limit),
+            ..self
+        })
+    }
+
+    /// Sets the order of the returned records.
+    ///
+    /// # Arguments
+    /// * `order` - An [`Order`] enum value specifying the order (ascending or descending).
+    ///
+    pub fn set_order(self, order: Order) -> AllOffersRequest {
+        AllOffersRequest {
+            order: Some(order),
+            ..self
+        }
+    }
+}

--- a/stellar_rust_sdk/src/offers/all_offers_request.rs
+++ b/stellar_rust_sdk/src/offers/all_offers_request.rs
@@ -1,5 +1,4 @@
 use crate::{models::*, BuildQueryParametersExt};
-
 use stellar_rust_sdk_derive::Pagination;
 use crate::Paginatable;
 
@@ -20,6 +19,8 @@ use crate::Paginatable;
 /// ```
 /// use stellar_rs::offers::all_offers_request::AllOffersRequest;
 /// use stellar_rs::models::{Asset, NativeAsset, Order};
+/// use stellar_rust_sdk_derive::Pagination;
+/// use stellar_rs::Paginatable;
 ///
 /// let request = AllOffersRequest::new()
 ///     .set_sponsor("GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5".to_string()).unwrap() // Optional sponsor filter
@@ -43,11 +44,9 @@ pub struct AllOffersRequest {
     seller: Option<String>,
     /// Optional. Indicates an selling asset for which offers are being queried.
     /// When set, the response will filter the offers that hold this specific asset.
-    // TODO: Make `NativeAsset` also possible
     selling: Option<Asset<IssuedAsset>>,
     /// Optional. Indicates a buying asset for which offers are being queried.
     /// When set, the response will filter the offers that hold this specific asset.
-    // TODO: Make `NativeAsset` also possible
     buying: Option<Asset<IssuedAsset>>,
     /// A pointer to a specific location in a collection of responses, derived from the
     /// `paging_token` value of a record. Used for pagination control in the API response.
@@ -142,50 +141,6 @@ impl AllOffersRequest {
     pub fn set_buying(self, buying: Asset<IssuedAsset>) -> AllOffersRequest {
         AllOffersRequest {
             buying: Some(buying),
-            ..self
-        }
-    }
-
-    /// Sets the cursor for pagination.
-    ///
-    /// # Arguments
-    /// * `cursor` - A `u32` value pointing to a specific location in a collection of responses.
-    ///
-    pub fn set_cursor(self, cursor: u32) -> Result<AllOffersRequest, String> {
-        if cursor < 1 {
-            return Err("cursor must be greater than or equal to 1".to_string());
-        }
-
-        Ok(AllOffersRequest {
-            cursor: Some(cursor),
-            ..self
-        })
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// # Arguments
-    /// * `limit` - A `u8` value specifying the maximum number of records. Range: 1 to 200. Defaults to 10.
-    ///
-    pub fn set_limit(self, limit: u8) -> Result<AllOffersRequest, String> {
-        if limit < 1 || limit > 200 {
-            return Err("limit must be between 1 and 200".to_string());
-        }
-
-        Ok(AllOffersRequest {
-            limit: Some(limit),
-            ..self
-        })
-    }
-
-    /// Sets the order of the returned records.
-    ///
-    /// # Arguments
-    /// * `order` - An [`Order`] enum value specifying the order (ascending or descending).
-    ///
-    pub fn set_order(self, order: Order) -> AllOffersRequest {
-        AllOffersRequest {
-            order: Some(order),
             ..self
         }
     }

--- a/stellar_rust_sdk/src/offers/mod.rs
+++ b/stellar_rust_sdk/src/offers/mod.rs
@@ -74,27 +74,28 @@ pub mod prelude {
 pub mod test {
     use super::prelude::*;
     use crate::horizon_client::HorizonClient;
+    use crate::models::*;
+
+    const LINK_SELF: &str = "https://horizon-testnet.stellar.org/offers/1";
+    const LINK_OFFER_MAKER: &str = "https://horizon-testnet.stellar.org/accounts/GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+    const OFFER_ID: &str = "1";
+    const PAGING_TOKEN: &str = "1";
+    const SELLER: &str = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+    const SELLING_ASSET_TYPE: &str = "credit_alphanum4";
+    const SELLING_ASSET_CODE: &str = "USDC";
+    const SELLING_ASSET_ISSUER: &str = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+    const BUYING_ASSET_TYPE: &str = "credit_alphanum12";
+    const BUYING_ASSET_CODE: &str = "USDCAllow";
+    const BUYING_ASSET_ISSUER: &str = "GAWZGWFOURKXZ4XYXBGFADZM4QIG6BJNM74XIZCEIU3BHM62RN2MDEZN";
+    const AMOUNT: &str = "909086990804.0875807";
+    const PRICE_R_N: &u32 = &1;
+    const PRICE_R_D: &u32 = &1;
+    const PRICE: &str = "1.0000000";
+    const LAST_MODIFIED_LEDGER: &u32 = &747543;
+    const LAST_MODIFIED_TIME: &str = "2024-03-23T04:51:18Z";
 
     #[tokio::test]
     async fn test_get_single_offer() {
-        const LINK_SELF: &str = "https://horizon-testnet.stellar.org/offers/1";
-        const LINK_OFFER_MAKER: &str = "https://horizon-testnet.stellar.org/accounts/GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
-        const OFFER_ID: &str = "1";
-        const PAGING_TOKEN: &str = "1";
-        const SELLER: &str = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
-        const SELLING_ASSET_TYPE: &str = "credit_alphanum4";
-        const SELLING_ASSET_CODE: &str = "USDC";
-        const SELLING_ASSET_ISSUER: &str = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
-        const BUYING_ASSET_TYPE: &str = "credit_alphanum12";
-        const BUYING_ASSET_CODE: &str = "USDCAllow";
-        const BUYING_ASSET_ISSUER: &str = "GAWZGWFOURKXZ4XYXBGFADZM4QIG6BJNM74XIZCEIU3BHM62RN2MDEZN";
-        const AMOUNT: &str = "909086990804.0875807";
-        const PRICE_R_N: &u32 = &1;
-        const PRICE_R_D: &u32 = &1;
-        const PRICE: &str = "1.0000000";
-        const LAST_MODIFIED_LEDGER: &u32 = &747543;
-        const LAST_MODIFIED_TIME: &str = "2024-03-23T04:51:18Z";
-
         let horizon_client =
             HorizonClient::new("https://horizon-testnet.stellar.org"
             .to_string())
@@ -128,5 +129,100 @@ pub mod test {
         assert_eq!(response.price_decimal(), PRICE);
         assert_eq!(response.last_modified_ledger(), LAST_MODIFIED_LEDGER);
         assert_eq!(response.last_modified_time(), LAST_MODIFIED_TIME);
+    }
+
+    #[tokio::test]
+    async fn test_get_all_offers() {
+        let horizon_client =
+            HorizonClient::new("https://horizon-testnet.stellar.org"
+            .to_string())
+            .unwrap();
+
+        // Create a request with no (optional) filters.
+        let all_offers_request =
+            AllOffersRequest::new();
+
+        let all_offers_response = horizon_client
+            .get_all_offers(&all_offers_request)
+            .await;
+
+        assert!(all_offers_response.clone().is_ok());
+        let binding = all_offers_response.unwrap();
+        let record = &binding.embedded().records()[0];
+        assert_eq!(record.links().self_link().href().as_ref().unwrap(), LINK_SELF);
+        assert_eq!(record.links().offer_maker().href().as_ref().unwrap(), LINK_OFFER_MAKER);
+        assert_eq!(record.id(), OFFER_ID);
+        assert_eq!(record.paging_token(), PAGING_TOKEN);
+        assert_eq!(record.seller(), SELLER);
+        assert_eq!(record.selling().asset_type(), SELLING_ASSET_TYPE);
+        assert_eq!(record.selling().asset_code().as_ref().unwrap(), SELLING_ASSET_CODE);
+        assert_eq!(record.selling().asset_issuer().as_ref().unwrap(), SELLING_ASSET_ISSUER);
+        assert_eq!(record.buying().asset_type(), BUYING_ASSET_TYPE);
+        assert_eq!(record.buying().asset_code().as_ref().unwrap(), BUYING_ASSET_CODE);
+        assert_eq!(record.buying().asset_issuer().as_ref().unwrap(), BUYING_ASSET_ISSUER);
+        assert_eq!(record.amount(), AMOUNT);
+        assert_eq!(record.price_ratio().numenator(), PRICE_R_N);
+        assert_eq!(record.price_ratio().denominator(), PRICE_R_D);
+        assert_eq!(record.price_decimal(), PRICE);
+        assert_eq!(record.last_modified_ledger(), LAST_MODIFIED_LEDGER);
+        assert_eq!(record.last_modified_time(), LAST_MODIFIED_TIME);
+    }
+
+    #[tokio::test]
+    async fn test_get_all_offers_filter() {
+        const LINK_OFFER_MAKER: &str = "https://horizon-testnet.stellar.org/accounts/GB3Q6QDZYTHWT7E5PVS3W7FUT5GVAFC5KSZFFLPU25GO7VTC3NM2ZTVO";
+        const OFFER_ID: &str = "2";
+        const PAGING_TOKEN: &str = "2";
+        const SELLER: &str = "GB3Q6QDZYTHWT7E5PVS3W7FUT5GVAFC5KSZFFLPU25GO7VTC3NM2ZTVO";
+        const SELLING_ASSET_TYPE: &str = "credit_alphanum4";
+        const SELLING_ASSET_CODE: &str = "EURC";
+        const SELLING_ASSET_ISSUER: &str = "GB3Q6QDZYTHWT7E5PVS3W7FUT5GVAFC5KSZFFLPU25GO7VTC3NM2ZTVO";
+        const BUYING_ASSET_TYPE: &str = "credit_alphanum12";
+        const BUYING_ASSET_CODE: &str = "EURCAllow";
+        const BUYING_ASSET_ISSUER: &str = "GA6HVGLFUF3BHHGR5CMYXIVZ3RYVUH5EUYAOAY4T3OKI5OQVIWVRK24R";
+        const AMOUNT: &str = "922320116343.5775807";
+        const PRICE_R_N: &u32 = &1;
+        const PRICE_R_D: &u32 = &1;
+        const PRICE: &str = "1.0000000";
+        const LAST_MODIFIED_LEDGER: &u32 = &1265238;
+        const LAST_MODIFIED_TIME: &str = "2024-04-23T16:33:24Z";
+    
+        let horizon_client =
+            HorizonClient::new("https://horizon-testnet.stellar.org"
+            .to_string())
+            .unwrap();
+
+        // Create a request and supply values for optional filters.
+        // TODO: Try to supply more filters and produce testable response results
+        let all_offers_request =
+            AllOffersRequest::new()
+            .set_seller(SELLER.to_string()).unwrap()
+            .set_cursor(1).unwrap()
+            .set_limit(100).unwrap()
+            .set_order(Order::Asc);
+
+        let all_offers_response = horizon_client
+            .get_all_offers(&all_offers_request)
+            .await;
+
+        assert!(all_offers_response.clone().is_ok());
+        let binding = all_offers_response.unwrap();
+        let record = &binding.embedded().records()[0];
+        assert_eq!(record.links().offer_maker().href().as_ref().unwrap(), LINK_OFFER_MAKER);
+        assert_eq!(record.id(), OFFER_ID);
+        assert_eq!(record.paging_token(), PAGING_TOKEN);
+        assert_eq!(record.seller(), SELLER);
+        assert_eq!(record.selling().asset_type(), SELLING_ASSET_TYPE);
+        assert_eq!(record.selling().asset_code().as_ref().unwrap(), SELLING_ASSET_CODE);
+        assert_eq!(record.selling().asset_issuer().as_ref().unwrap(), SELLING_ASSET_ISSUER);
+        assert_eq!(record.buying().asset_type(), BUYING_ASSET_TYPE);
+        assert_eq!(record.buying().asset_code().as_ref().unwrap(), BUYING_ASSET_CODE);
+        assert_eq!(record.buying().asset_issuer().as_ref().unwrap(), BUYING_ASSET_ISSUER);
+        assert_eq!(record.amount(), AMOUNT);
+        assert_eq!(record.price_ratio().numenator(), PRICE_R_N);
+        assert_eq!(record.price_ratio().denominator(), PRICE_R_D);
+        assert_eq!(record.price_decimal(), PRICE);
+        assert_eq!(record.last_modified_ledger(), LAST_MODIFIED_LEDGER);
+        assert_eq!(record.last_modified_time(), LAST_MODIFIED_TIME);
     }
 }

--- a/stellar_rust_sdk/src/offers/mod.rs
+++ b/stellar_rust_sdk/src/offers/mod.rs
@@ -7,6 +7,15 @@
 ///
 pub mod single_offer_request;
 
+/// Provides the `AllOffersRequest`.
+///
+/// This module provides the `AllOffersRequest` struct, specifically designed for
+/// constructing requests to query information about all offers from the Horizon
+/// server. It is tailored for use with the [`HorizonClient::get_all_offers`](crate::horizon_client::HorizonClient::get_all_offers)
+/// method.
+///
+pub mod all_offers_request;
+
 /// Provides the responses.
 ///
 /// This module defines structures representing the response from the Horizon API when querying

--- a/stellar_rust_sdk/src/offers/mod.rs
+++ b/stellar_rust_sdk/src/offers/mod.rs
@@ -73,8 +73,7 @@ pub mod prelude {
 #[cfg(test)]
 pub mod test {
     use super::prelude::*;
-    use crate::horizon_client::HorizonClient;
-    use crate::models::*;
+    use crate::{horizon_client::HorizonClient, models::*, Paginatable};
 
     const LINK_SELF: &str = "https://horizon-testnet.stellar.org/offers/1";
     const LINK_OFFER_MAKER: &str = "https://horizon-testnet.stellar.org/accounts/GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
@@ -180,12 +179,12 @@ pub mod test {
         const BUYING_ASSET_TYPE: &str = "credit_alphanum12";
         const BUYING_ASSET_CODE: &str = "EURCAllow";
         const BUYING_ASSET_ISSUER: &str = "GA6HVGLFUF3BHHGR5CMYXIVZ3RYVUH5EUYAOAY4T3OKI5OQVIWVRK24R";
-        const AMOUNT: &str = "922320116343.5775807";
+        const AMOUNT: &str = "922320116343.0475807";
         const PRICE_R_N: &u32 = &1;
         const PRICE_R_D: &u32 = &1;
         const PRICE: &str = "1.0000000";
-        const LAST_MODIFIED_LEDGER: &u32 = &1265238;
-        const LAST_MODIFIED_TIME: &str = "2024-04-23T16:33:24Z";
+        const LAST_MODIFIED_LEDGER: &u32 = &1384257;
+        const LAST_MODIFIED_TIME: &str = "2024-04-30T22:19:21Z";
     
         let horizon_client =
             HorizonClient::new("https://horizon-testnet.stellar.org"
@@ -193,13 +192,12 @@ pub mod test {
             .unwrap();
 
         // Create a request and supply values for optional filters.
-        // TODO: Try to supply more filters and produce testable response results
         let all_offers_request =
             AllOffersRequest::new()
             .set_seller(SELLER.to_string()).unwrap()
             .set_cursor(1).unwrap()
             .set_limit(100).unwrap()
-            .set_order(Order::Asc);
+            .set_order(Order::Asc).unwrap();
 
         let all_offers_response = horizon_client
             .get_all_offers(&all_offers_request)

--- a/stellar_rust_sdk/src/offers/mod.rs
+++ b/stellar_rust_sdk/src/offers/mod.rs
@@ -51,6 +51,7 @@ static OFFERS_PATH: &str = "offers";
 /// The `prelude` includes the following re-exports:
 ///
 /// * From `single_offer_request`: All items (e.g. `SingleOfferRequest`).
+/// * From `all_offers_request`: All items (e.g. `AllOffersRequest`).
 /// * From `response`: All items (e.g. `SingleOfferResponse`, `PriceR`, etc.).
 ///
 /// # Example
@@ -65,6 +66,7 @@ static OFFERS_PATH: &str = "offers";
 ///
 pub mod prelude {
     pub use super::single_offer_request::*;
+    pub use super::all_offers_request::*;
     pub use super::response::*;
 }
 

--- a/stellar_rust_sdk/src/offers/response.rs
+++ b/stellar_rust_sdk/src/offers/response.rs
@@ -2,12 +2,30 @@ use crate::models::prelude::*;
 use derive_getters::Getters;
 use serde::{Deserialize, Serialize};
 
+
+#[derive(Debug, Clone, Serialize, Deserialize, Getters)]
+#[serde(rename_all = "camelCase")]
+pub struct AllOffersResponse {
+    #[serde(rename = "_links")]
+    pub links: ResponseLinks,
+    #[serde(rename = "_embedded")]
+    pub embedded: Embedded<OfferResponse>,
+}
+
+impl Response for AllOffersResponse {
+    fn from_json(json: String) -> Result<Self, String> {
+        let response = serde_json::from_str(&json).map_err(|e| e.to_string())?;
+
+        Ok(response)
+    }
+}
+
 /// Represents the asset to buy or to sell.
 ///
 /// This struct details information about the asset to buy or to sell, including its type, 
 /// code (optional) and issuer (optional).
 ///
-#[derive(Debug, Deserialize, Clone, Getters)]
+#[derive(Debug, Deserialize, Serialize, Clone, Getters)]
 pub struct Transaction {
     /// The type of asset (e.g. "credit_alphanum4", "credit_alphanum12").
     asset_type: String,
@@ -22,7 +40,7 @@ pub struct Transaction {
 /// This struct contains a numenator and a denominator, so that the price ratio can be determined
 /// in a precise manner.
 ///
-#[derive(Debug, Deserialize, Clone, Getters)]
+#[derive(Debug, Deserialize, Serialize, Clone, Getters)]
 pub struct PriceR {
     /// The numenator.
     #[serde(rename = "n")]
@@ -38,7 +56,7 @@ pub struct PriceR {
 /// and the offer maker.
 ///
 #[derive(Debug, Deserialize, Serialize, Clone, Getters)]
-pub struct OfferResponseLinks {
+pub struct Links {
     /// The link to the offer itself.
     #[serde(rename = "self")]
     self_link: Link,
@@ -52,11 +70,11 @@ pub struct OfferResponseLinks {
 /// It includes navigational links, offer identifiers, the seller, the assets to buy and sell,
 /// the amount, the price and additional data.
 ///
-#[derive(Debug, Deserialize, Clone, Getters)]
-pub struct SingleOfferResponse {
+#[derive(Debug, Deserialize, Serialize, Clone, Getters)]
+pub struct OfferResponse {
     /// Navigational links related to the offer.
     #[serde(rename = "_links")]
-    links: OfferResponseLinks,
+    links: Links,
     /// The unique identifier for the offer.
     id: String,
     /// A token used for paging through results.
@@ -83,7 +101,7 @@ pub struct SingleOfferResponse {
     sponsor: Option<String>,
 }
 
-impl Response for SingleOfferResponse {
+impl Response for OfferResponse {
     fn from_json(json: String) -> Result<Self, String> {
         serde_json::from_str(&json).map_err(|e| e.to_string())
     }

--- a/stellar_rust_sdk/src/offers/response.rs
+++ b/stellar_rust_sdk/src/offers/response.rs
@@ -2,7 +2,11 @@ use crate::models::prelude::*;
 use derive_getters::Getters;
 use serde::{Deserialize, Serialize};
 
-
+/// Represents the response for the 'all offers' query in the Horizon API.
+///
+/// This struct defines the overall structure of the response for an 'all offers' query.
+/// It includes navigational links and embedded results.
+///
 #[derive(Debug, Clone, Serialize, Deserialize, Getters)]
 #[serde(rename_all = "camelCase")]
 pub struct AllOffersResponse {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This PR adds the 'all offers' endpoint.

**Note:** in the request, currently only *issued assets* can be supplied. We need to discuss ideas for making it possible to include *native Assets*.

### :arrow_heading_down: What is the current behavior?
Only the *single offer* endpoint was included. 

### :new: What is the new behavior (if this is a feature change)?
-

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
-

### :memo: Links to relevant issues/docs
-

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current main
