### PR TITLE
All transactions endpoint

### DIFF
--- a/stellar_rust_sdk/src/horizon_client.rs
+++ b/stellar_rust_sdk/src/horizon_client.rs
@@ -1382,6 +1382,15 @@ impl HorizonClient {
         self.get::<TransactionResponse>(request).await
     }
 
+    // TODO: Documentation
+    pub async fn get_all_transactions(
+        &self,
+        request: &AllTransactionsRequest,
+    ) -> Result<AllTransactionsResponse, String> {
+        self.get::<AllTransactionsResponse>(request).await
+    }
+
+
 }
 
 /// Handles the response received from an HTTP request made to the Horizon server.

--- a/stellar_rust_sdk/src/horizon_client.rs
+++ b/stellar_rust_sdk/src/horizon_client.rs
@@ -1382,15 +1382,58 @@ impl HorizonClient {
         self.get::<TransactionResponse>(request).await
     }
 
-    // TODO: Documentation
+
+    /// Retrieves a list of all transactions from the Horizon server.
+    ///
+    /// This asynchronous method fetches a list of all transactions from the Horizon server.
+    /// It requires an [`AllTransactionsRequest`] to specify the optional query parameters.
+    ///
+    /// # Arguments
+    /// * `request` - A reference to an [`AllTransactionsRequest`] instance, containing the
+    /// parameters for the transactions request.
+    ///
+    /// # Returns
+    ///
+    /// On successful execution, returns a `Result` containing an [`AllTransactionsResponse`], which includes
+    /// the list of all transactions obtained from the Horizon server. If the request fails, it returns an error within `Result`.
+    ///
+    /// # Usage
+    /// To use this method, create an instance of [`AllTransactionsRequest`] and set any desired
+    /// filters or parameters.
+    ///
+    /// ```
+    /// # use stellar_rs::transactions::prelude::*;
+    /// # use stellar_rs::models::Request;
+    /// # use stellar_rs::horizon_client::HorizonClient;
+    /// # use stellar_rust_sdk_derive::Pagination;
+    /// # use stellar_rs::Paginatable;
+    /// #
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
+    /// # let horizon_client = HorizonClient::new(base_url)
+    /// #    .expect("Failed to create Horizon Client");
+    /// let request = AllTransactionsRequest::new()
+    ///   .set_include_failed(true).unwrap();
+    ///
+    /// let response = horizon_client.get_all_transactions(&request).await;
+    ///
+    /// // Access the transactions
+    /// if let Ok(transactions_response) = response {
+    ///     for transaction in transactions_response.embedded().records() {
+    ///         println!("Transaction ID: {}", transaction.id());
+    ///         // Further processing...
+    ///     }
+    /// }
+    /// # Ok({})
+    /// # }
+    /// ```
+    ///
     pub async fn get_all_transactions(
         &self,
         request: &AllTransactionsRequest,
     ) -> Result<AllTransactionsResponse, String> {
         self.get::<AllTransactionsResponse>(request).await
     }
-
-
 }
 
 /// Handles the response received from an HTTP request made to the Horizon server.

--- a/stellar_rust_sdk/src/transactions/all_transactions_request.rs
+++ b/stellar_rust_sdk/src/transactions/all_transactions_request.rs
@@ -2,7 +2,35 @@ use crate::{models::*, BuildQueryParametersExt};
 use stellar_rust_sdk_derive::Pagination;
 use crate::Paginatable;
 
-// TODO: Documentation
+/// Represents a request to list all transactions from the Stellar Horizon API.
+///
+/// This structure is used to construct a query to retrieve a comprehensive list of transactions, which
+/// can be filtered by setting `include_failed`. It adheres to the structure and parameters required
+/// by the Horizon API for retrieving a
+/// <a href="https://developers.stellar.org/network/horizon/api-reference/resources/list-all-transactions">list of all transactions</a>.
+///
+/// # Usage
+///
+/// Create an instance of this struct and set the desired query parameters to filter the list of transactions.
+/// Pass this request object to the [`HorizonClient::get_all_transactions`](crate::horizon_client::HorizonClient::get_all_transactions)
+/// method to fetch the corresponding data from the Horizon API.
+///
+/// # Example
+/// ```
+/// use stellar_rs::transactions::all_transactions_request::AllTransactionsRequest;
+/// use stellar_rs::models::{Order};
+/// use stellar_rust_sdk_derive::Pagination;
+/// use stellar_rs::Paginatable;
+///
+/// let request = AllTransactionsRequest::new()
+///     .set_include_failed(true).unwrap() // Optional flag to include failed transactions
+///     .set_cursor(123).unwrap() // Optional cursor for pagination
+///     .set_limit(100).unwrap() // Optional limit for response records
+///     .set_order(Order::Desc); // Optional order of records
+///
+/// // Use with HorizonClient::get_all_transactions
+/// ```
+///
 #[derive(Default, Pagination)]
 pub struct AllTransactionsRequest {
     // Indicates whether or not to include failed operations in the response.
@@ -29,7 +57,6 @@ impl Request for AllTransactionsRequest {
         .build_query_parameters()
     }
 
-    // TODO: Documentation
     fn build_url(&self, base_url: &str) -> String {
         format!(
             "{}/{}{}",
@@ -46,7 +73,10 @@ impl AllTransactionsRequest {
         AllTransactionsRequest::default()
     }
 
-    // TODO: Documentation
+    /// Specifies whether to include failed operations in the response.
+    ///
+    /// # Arguments
+    /// * `include_failed` (bool) - when set to `true`, failed operations will be included.
     pub fn set_include_failed(self, include_failed: bool) -> Result<AllTransactionsRequest, String> {
         Ok(AllTransactionsRequest {
             include_failed: Some(include_failed),

--- a/stellar_rust_sdk/src/transactions/all_transactions_request.rs
+++ b/stellar_rust_sdk/src/transactions/all_transactions_request.rs
@@ -1,0 +1,56 @@
+use crate::{models::*, BuildQueryParametersExt};
+use stellar_rust_sdk_derive::Pagination;
+use crate::Paginatable;
+
+// TODO: Documentation
+#[derive(Default, Pagination)]
+pub struct AllTransactionsRequest {
+    // Indicates whether or not to include failed operations in the response.
+    include_failed: Option<bool>,
+    /// A pointer to a specific location in a collection of responses, derived from the
+    /// `paging_token` value of a record. Used for pagination control in the API response.
+    cursor: Option<u32>,
+    /// Specifies the maximum number of records to be returned in a single response.
+    /// The range for this parameter is from 1 to 200. The default value is set to 10.
+    limit: Option<u8>,
+    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
+    /// and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
+    order: Option<Order>,
+}
+
+impl Request for AllTransactionsRequest {
+    fn get_query_parameters(&self) -> String {
+        vec![
+            self.include_failed.as_ref().map(|i| format!("include_failed={}", i)),
+            self.cursor.as_ref().map(|c| format!("cursor={}", c)),
+            self.limit.as_ref().map(|l| format!("limit={}", l)),
+            self.order.as_ref().map(|o| format!("order={}", o)),
+        ]
+        .build_query_parameters()
+    }
+
+    // TODO: Documentation
+    fn build_url(&self, base_url: &str) -> String {
+        format!(
+            "{}/{}{}",
+            base_url,
+            super::TRANSACTIONS_PATH,
+            self.get_query_parameters()
+        )
+    }
+}
+
+impl AllTransactionsRequest {
+    /// Creates a new `AllTransactionsRequest` with default parameters.
+    pub fn new() -> Self {
+        AllTransactionsRequest::default()
+    }
+
+    // TODO: Documentation
+    pub fn set_include_failed(self, include_failed: bool) -> Result<AllTransactionsRequest, String> {
+        Ok(AllTransactionsRequest {
+            include_failed: Some(include_failed),
+            ..self
+        })
+    }
+}

--- a/stellar_rust_sdk/src/transactions/mod.rs
+++ b/stellar_rust_sdk/src/transactions/mod.rs
@@ -8,7 +8,14 @@
 ///
 pub mod single_transaction_request;
 
-/// TODO: Documentation
+/// Provides the `AllTransactionsRequest`.
+///
+/// # Usage
+/// This module provides the `AllTransactionsRequest` struct, specifically designed for
+/// constructing requests to query information about all transactions from the Horizon
+/// server. It is tailored for use with the [`HorizonClient::get_all_transactions`](crate::horizon_client::HorizonClient::get_all_transactions)
+/// method.
+///
 pub mod all_transactions_request;
 
 /// Provides the responses.
@@ -26,7 +33,7 @@ pub mod response;
 ///
 /// # Usage
 /// This variable is intended to be used internally by the request-building logic
-/// to ensure consistent and accurate path construction for offer-related API calls.
+/// to ensure consistent and accurate path construction for transaction-related API calls.
 static TRANSACTIONS_PATH: &str = "transactions";
 
 /// The `prelude` module of the `transactions` module.
@@ -67,7 +74,7 @@ pub mod prelude {
 #[cfg(test)]
 pub mod test {
     use super::prelude::*;
-    use crate::{horizon_client::HorizonClient, models::Request};
+    use crate::horizon_client::HorizonClient;
 
     #[tokio::test]
     async fn test_get_single_transaction() {
@@ -179,7 +186,8 @@ pub mod test {
             .to_string())
             .unwrap();
 
-        let all_transactions_request = AllTransactionsRequest::new().set_include_failed(true).unwrap();
+        let all_transactions_request = AllTransactionsRequest::new()
+            .set_include_failed(true).unwrap();
 
         let all_transactions_response = horizon_client
             .get_all_transactions(&all_transactions_request)

--- a/stellar_rust_sdk/src/transactions/response.rs
+++ b/stellar_rust_sdk/src/transactions/response.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 /// the ledger that the transaction was included in.
 ///
 #[derive(Debug, Deserialize, Serialize, Clone, Getters)]
-pub struct Links {
+pub struct TransactionResponseLinks {
     #[serde(rename = "self")]
     self_link: Link,
     account: Link,
@@ -72,6 +72,24 @@ pub struct LedgerBounds {
     max_ledger: Option<String>,
 }
 
+// TODO: Documentation
+#[derive(Debug, Clone, Serialize, Deserialize, Getters)]
+#[serde(rename_all = "camelCase")]
+pub struct AllTransactionsResponse {
+    #[serde(rename = "_links")]
+    links: ResponseLinks,
+    #[serde(rename = "_embedded")]
+    embedded: Embedded<TransactionResponse>,
+}
+
+impl Response for AllTransactionsResponse {
+    fn from_json(json: String) -> Result<Self, String> {
+        let response = serde_json::from_str(&json).map_err(|e| e.to_string())?;
+
+        Ok(response)
+    }
+}
+
 /// Represents a single transaction record in the Horizon API response.
 ///
 /// # Usage
@@ -81,7 +99,7 @@ pub struct LedgerBounds {
 #[derive(Debug, Clone, Serialize, Deserialize, Getters)]
 pub struct TransactionResponse {
         #[serde(rename = "_links")]
-        links: Links,
+        links: TransactionResponseLinks,
         /// A unique identifier for this transaction.
         id: String,
         /// A cursor value for use in pagination.
@@ -127,7 +145,7 @@ pub struct TransactionResponse {
         /// The date after which a transaction is valid. 
         valid_after: String,
         /// The date before which a transaction is valid.
-        valid_before: String,
+        valid_before: Option<String>,
         /// A set of transaction preconditions affecting its validity.
         preconditions: Preconditions,
 }

--- a/stellar_rust_sdk/src/transactions/response.rs
+++ b/stellar_rust_sdk/src/transactions/response.rs
@@ -72,7 +72,11 @@ pub struct LedgerBounds {
     max_ledger: Option<String>,
 }
 
-// TODO: Documentation
+/// Represents the response for the 'all transactions' query in the Horizon API.
+///
+/// This struct defines the overall structure of the response for an 'all transactions' query.
+/// It includes navigational links and embedded results.
+///
 #[derive(Debug, Clone, Serialize, Deserialize, Getters)]
 #[serde(rename_all = "camelCase")]
 pub struct AllTransactionsResponse {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Adds the 'all transactions' endpoint to the Transactions endpoint group.

Also makes the `valid_before` field in the response struct optional, as the testing for all transactions showed that this value isn't always included in the response. This is not mentioned in the Stellar documentation.

Lastly, the `Links` struct in the response is renamed to a dedicated name, to avoid future naming conflicts.

### :boom: Does this PR introduce a breaking change?
No.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current main
