### PR TITLE
Apply pagination macro to all requests

### DIFF
--- a/stellar_rust_sdk/src/assets/all_assets_request.rs
+++ b/stellar_rust_sdk/src/assets/all_assets_request.rs
@@ -1,4 +1,5 @@
-use crate::{models::*, BuildQueryParametersExt};
+use crate::{models::*, BuildQueryParametersExt, Paginatable};
+use stellar_rust_sdk_derive::Pagination;
 
 /// Represents a request for listing all assets in the Stellar Horizon API.
 ///
@@ -17,6 +18,8 @@ use crate::{models::*, BuildQueryParametersExt};
 /// # use stellar_rs::assets::prelude::{AllAssetsRequest, AllAssetsResponse};
 /// # use stellar_rs::models::*;
 /// # use stellar_rs::horizon_client::HorizonClient;
+/// # use stellar_rust_sdk_derive::Pagination;
+/// # use stellar_rs::Paginatable;
 /// #
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
@@ -29,13 +32,13 @@ use crate::{models::*, BuildQueryParametersExt};
 ///     .set_limit(20)?
 ///     .set_order(Order::Desc);
 ///
-/// let response = horizon_client.get_all_assets(&request).await;
+/// let response = horizon_client.get_all_assets(&request.unwrap()).await;
 /// # Ok({})
 /// # }
 ///
 /// ```
 ///
-#[derive(Default)]
+#[derive(Default, Pagination)]
 pub struct AllAssetsRequest {
     /// The code of the asset to filter by. This is typically the identifier
     ///   assigned to custom assets on the Stellar network.
@@ -51,7 +54,7 @@ pub struct AllAssetsRequest {
 
     /// Specifies the maximum number of records to be returned in a single response.
     ///   The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u32>,
+    limit: Option<u8>,
 
     /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
     ///   and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
@@ -129,50 +132,6 @@ impl AllAssetsRequest {
             ..self
         })
     }
-
-    /// Sets the cursor for pagination.
-    ///
-    /// # Arguments
-    /// * `cursor` - A `u32` value pointing to a specific location in a collection of responses.
-    ///
-    pub fn set_cursor(self, cursor: u32) -> Result<AllAssetsRequest, String> {
-        if cursor < 1 {
-            return Err("cursor must be greater than or equal to 1".to_string());
-        }
-
-        Ok(AllAssetsRequest {
-            cursor: Some(cursor),
-            ..self
-        })
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// # Arguments
-    /// * `limit` - A `u8` value specifying the maximum number of records. Range: 1 to 200. Defaults to 10.
-    ///
-    pub fn set_limit(self, limit: u32) -> Result<AllAssetsRequest, String> {
-        if limit < 1 || limit > 200 {
-            return Err("limit must be between 1 and 200".to_string());
-        }
-
-        Ok(AllAssetsRequest {
-            limit: Some(limit),
-            ..self
-        })
-    }
-
-    /// Sets the order of the returned records.
-    ///
-    /// # Arguments
-    /// * `order` - An [`Order`] enum value specifying the order (ascending or descending).
-    ///
-    pub fn set_order(self, order: Order) -> AllAssetsRequest {
-        AllAssetsRequest {
-            order: Some(order),
-            ..self
-        }
-    }
 }
 
 #[cfg(test)]
@@ -226,7 +185,7 @@ mod tests {
         let request = AllAssetsRequest::new().set_cursor(0);
         assert_eq!(
             request.err().unwrap(),
-            "cursor must be greater than or equal to 1".to_string()
+            "Cursor must be greater than or equal to 1.".to_string()
         );
     }
 
@@ -241,7 +200,7 @@ mod tests {
         let request = AllAssetsRequest::new().set_limit(0);
         assert_eq!(
             request.err().unwrap(),
-            "limit must be between 1 and 200".to_string()
+            "Limit must be between 1 and 200.".to_string()
         );
     }
 
@@ -250,7 +209,7 @@ mod tests {
         let request = AllAssetsRequest::new().set_limit(201);
         assert_eq!(
             request.err().unwrap(),
-            "limit must be between 1 and 200".to_string()
+            "Limit must be between 1 and 200.".to_string()
         );
     }
 }

--- a/stellar_rust_sdk/src/assets/mod.rs
+++ b/stellar_rust_sdk/src/assets/mod.rs
@@ -75,9 +75,8 @@ pub mod prelude {
 
 #[cfg(test)]
 pub mod test {
-
     use super::prelude::*;
-    use crate::horizon_client::HorizonClient;
+    use crate::{horizon_client::HorizonClient, Paginatable};
 
     #[tokio::test]
     async fn test_get_all_assets() {

--- a/stellar_rust_sdk/src/claimable_balances/all_claimable_balances_request.rs
+++ b/stellar_rust_sdk/src/claimable_balances/all_claimable_balances_request.rs
@@ -1,4 +1,5 @@
-use crate::{models::*, BuildQueryParametersExt};
+use crate::{models::*, BuildQueryParametersExt, Paginatable};
+use stellar_rust_sdk_derive::Pagination;
 
 /// Represents a request to list all claimable balances from the Stellar Horizon API.
 ///
@@ -16,8 +17,9 @@ use crate::{models::*, BuildQueryParametersExt};
 ///
 /// # Example
 /// ```
-/// use stellar_rs::claimable_balances::all_claimable_balances_request::AllClaimableBalancesRequest;
-/// use stellar_rs::models::{Asset, Order, IssuedAsset};
+/// # use stellar_rs::claimable_balances::all_claimable_balances_request::AllClaimableBalancesRequest;
+/// # use stellar_rs::models::{Asset, Order, IssuedAsset};
+/// # use crate::stellar_rs::Paginatable;
 ///
 /// let request = AllClaimableBalancesRequest::new()
 ///     .set_sponsor("GDQJUTQYK2MQX2VGDR2FYWLIYAQIEGXTQVTFEMGH2BEWFG4BRUY4CKI7".to_string()).unwrap() // Optional sponsor filter
@@ -30,7 +32,7 @@ use crate::{models::*, BuildQueryParametersExt};
 /// // Use with HorizonClient::get_all_claimable_balances
 /// ```
 ///
-#[derive(Default)]
+#[derive(Default, Pagination)]
 pub struct AllClaimableBalancesRequest {
     /// Optional. Representing the account ID of the sponsor. When set, the response will
     ///   only include claimable balances sponsored by the specified account.
@@ -50,7 +52,7 @@ pub struct AllClaimableBalancesRequest {
 
     /// Specifies the maximum number of records to be returned in a single response.
     ///   The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u32>,
+    limit: Option<u8>,
 
     /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
     ///   and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
@@ -129,50 +131,6 @@ impl AllClaimableBalancesRequest {
             ..self
         })
     }
-
-    /// Sets the cursor for pagination.
-    ///
-    /// # Arguments
-    /// * `cursor` - A `u32` value pointing to a specific location in a collection of responses.
-    ///
-    pub fn set_cursor(self, cursor: u32) -> Result<AllClaimableBalancesRequest, String> {
-        if cursor < 1 {
-            return Err("cursor must be greater than or equal to 1".to_string());
-        }
-
-        Ok(AllClaimableBalancesRequest {
-            cursor: Some(cursor),
-            ..self
-        })
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// # Arguments
-    /// * `limit` - A `u8` value specifying the maximum number of records. Range: 1 to 200. Defaults to 10.
-    ///
-    pub fn set_limit(self, limit: u32) -> Result<AllClaimableBalancesRequest, String> {
-        if limit < 1 || limit > 200 {
-            return Err("limit must be between 1 and 200".to_string());
-        }
-
-        Ok(AllClaimableBalancesRequest {
-            limit: Some(limit),
-            ..self
-        })
-    }
-
-    /// Sets the order of the returned records.
-    ///
-    /// # Arguments
-    /// * `order` - An [`Order`] enum value specifying the order (ascending or descending).
-    ///
-    pub fn set_order(self, order: Order) -> AllClaimableBalancesRequest {
-        AllClaimableBalancesRequest {
-            order: Some(order),
-            ..self
-        }
-    }
 }
 
 #[cfg(test)]
@@ -192,7 +150,7 @@ mod tests {
         let request = AllClaimableBalancesRequest::new().set_cursor(0);
         assert_eq!(
             request.err().unwrap(),
-            "cursor must be greater than or equal to 1".to_string()
+            "Cursor must be greater than or equal to 1.".to_string()
         );
     }
 
@@ -207,7 +165,7 @@ mod tests {
         let request = AllClaimableBalancesRequest::new().set_limit(0);
         assert_eq!(
             request.err().unwrap(),
-            "limit must be between 1 and 200".to_string()
+            "Limit must be between 1 and 200.".to_string()
         );
     }
 
@@ -216,7 +174,7 @@ mod tests {
         let request = AllClaimableBalancesRequest::new().set_limit(201);
         assert_eq!(
             request.err().unwrap(),
-            "limit must be between 1 and 200".to_string()
+            "Limit must be between 1 and 200.".to_string()
         );
     }
 }

--- a/stellar_rust_sdk/src/claimable_balances/mod.rs
+++ b/stellar_rust_sdk/src/claimable_balances/mod.rs
@@ -89,16 +89,14 @@ fn parse_epoch(epoch_str: &str) -> DateTime<Utc> {
 }
 
 pub mod prelude {
-    pub use super::all_claimable_balances_request::*;
-    pub use super::response::*;
-    pub use super::single_claimable_balance_request::*;
+    pub use super::{all_claimable_balances_request::*, response::*, single_claimable_balance_request::*};
 }
 
 #[cfg(test)]
 mod tests {
     use super::parse_epoch;
     use super::prelude::*;
-    use crate::horizon_client::HorizonClient;
+    use crate::{horizon_client::HorizonClient, Paginatable};
     use chrono::DateTime;
     use chrono::{TimeZone, Utc};
     use lazy_static::lazy_static;

--- a/stellar_rust_sdk/src/effects/all_effects_request.rs
+++ b/stellar_rust_sdk/src/effects/all_effects_request.rs
@@ -1,5 +1,5 @@
-use crate::{models::*, BuildQueryParametersExt};
-
+use crate::{models::*, BuildQueryParametersExt, Paginatable};
+use stellar_rust_sdk_derive::Pagination;
 /// Represents a request to fetch effect data from the Stellar Horizon API.
 ///
 /// `AllEffectsRequest` is a struct used to construct queries for retrieving information about effects
@@ -13,8 +13,10 @@ use crate::{models::*, BuildQueryParametersExt};
 ///
 /// # Example
 /// ```rust
-/// use stellar_rs::effects::all_effects_request::AllEffectsRequest;
-/// use stellar_rs::models::*;
+/// # use stellar_rs::effects::all_effects_request::AllEffectsRequest;
+/// # use stellar_rs::models::*;
+/// # use stellar_rust_sdk_derive::Pagination;
+/// # use crate::stellar_rs::Paginatable;
 ///
 /// let request = AllEffectsRequest::new()
 ///     .set_cursor(1234).unwrap()
@@ -24,7 +26,7 @@ use crate::{models::*, BuildQueryParametersExt};
 /// // The request can now be used with a Horizon client to fetch effects.
 /// ```
 ///
-#[derive(Default)]
+#[derive(Default, Pagination)]
 pub struct AllEffectsRequest {
     /// A pointer to a specific location in a collection of responses, derived from the
     ///   `paging_token` value of a record. Used for pagination control in the API response.
@@ -43,50 +45,6 @@ impl AllEffectsRequest {
     /// Creates a new `AllEffectsRequest` with default parameters.
     pub fn new() -> Self {
         AllEffectsRequest::default()
-    }
-
-    /// Sets the cursor for pagination.
-    ///
-    /// # Arguments
-    /// * `cursor` - A `u32` value pointing to a specific location in a collection of responses.
-    ///
-    pub fn set_cursor(self, cursor: u32) -> Result<AllEffectsRequest, String> {
-        if cursor < 1 {
-            return Err("cursor must be greater than or equal to 1".to_string());
-        }
-
-        Ok(AllEffectsRequest {
-            cursor: Some(cursor),
-            ..self
-        })
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// # Arguments
-    /// * `limit` - A `u8` value specifying the maximum number of records. Range: 1 to 200. Defaults to 10.
-    ///
-    pub fn set_limit(self, limit: u8) -> Result<AllEffectsRequest, String> {
-        if limit < 1 || limit > 200 {
-            return Err("limit must be between 1 and 200".to_string());
-        }
-
-        Ok(AllEffectsRequest {
-            limit: Some(limit),
-            ..self
-        })
-    }
-
-    /// Sets the order of the returned records.
-    ///
-    /// # Arguments
-    /// * `order` - An [`Order`] enum value specifying the order (ascending or descending).
-    ///
-    pub fn set_order(self, order: Order) -> AllEffectsRequest {
-        AllEffectsRequest {
-            order: Some(order),
-            ..self
-        }
     }
 }
 

--- a/stellar_rust_sdk/src/effects/effects_for_account_request.rs
+++ b/stellar_rust_sdk/src/effects/effects_for_account_request.rs
@@ -1,7 +1,9 @@
 use crate::{
     models::{Order, Request},
     BuildQueryParametersExt,
+    Paginatable,
 };
+use stellar_rust_sdk_derive::Pagination;
 
 /// Represents the request to fetch effects for a specific account from the Horizon API.
 ///
@@ -22,8 +24,10 @@ use crate::{
 ///
 /// # Example
 /// ```rust
-/// use stellar_rs::effects::effects_for_account_request::EffectsForAccountRequest;
-/// use stellar_rs::models::*;
+/// # use stellar_rs::effects::effects_for_account_request::EffectsForAccountRequest;
+/// # use stellar_rs::models::*;
+/// # use stellar_rust_sdk_derive::Pagination;
+/// # use crate::stellar_rs::Paginatable;
 ///
 /// let request = EffectsForAccountRequest::new()
 ///     .set_cursor(1234).unwrap()
@@ -34,7 +38,7 @@ use crate::{
 /// ```
 ///
 
-#[derive(Default)]
+#[derive(Default, Pagination)]
 pub struct EffectsForAccountRequest {
     /// The accounts public id
     account_id: Option<String>,
@@ -66,50 +70,6 @@ impl EffectsForAccountRequest {
     pub fn set_account_id(self, account_id: String) -> EffectsForAccountRequest {
         EffectsForAccountRequest {
             account_id: Some(account_id),
-            ..self
-        }
-    }
-
-    /// Sets the cursor for pagination.
-    ///
-    /// # Arguments
-    /// * `cursor` - A `u32` value pointing to a specific location in a collection of responses.
-    ///
-    pub fn set_cursor(self, cursor: u32) -> Result<EffectsForAccountRequest, String> {
-        if cursor < 1 {
-            return Err("cursor must be greater than or equal to 1".to_string());
-        }
-
-        Ok(EffectsForAccountRequest {
-            cursor: Some(cursor),
-            ..self
-        })
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// # Arguments
-    /// * `limit` - A `u8` value specifying the maximum number of records. Range: 1 to 200. Defaults to 10.
-    ///
-    pub fn set_limit(self, limit: u8) -> Result<EffectsForAccountRequest, String> {
-        if limit < 1 || limit > 200 {
-            return Err("limit must be between 1 and 200".to_string());
-        }
-
-        Ok(EffectsForAccountRequest {
-            limit: Some(limit),
-            ..self
-        })
-    }
-
-    /// Sets the order of the returned records.
-    ///
-    /// # Arguments
-    /// * `order` - An [`Order`] enum value specifying the order (ascending or descending).
-    ///
-    pub fn set_order(self, order: Order) -> EffectsForAccountRequest {
-        EffectsForAccountRequest {
-            order: Some(order),
             ..self
         }
     }
@@ -157,7 +117,8 @@ mod tests {
             .unwrap()
             .set_limit(10)
             .unwrap()
-            .set_order(Order::Desc);
+            .set_order(Order::Desc)
+            .unwrap();
         assert_eq!(
             request.build_url("https://horizon-testnet.stellar.org"),
             "https://horizon-testnet.stellar.org/effects?account=GBL3QJ2MB3KJ7YV7YVXJ5ZL5V6Z5ZL5V6Z5ZL5V6Z5ZL5V6Z5ZL5V6Z&cursor=1&limit=10&order=desc"

--- a/stellar_rust_sdk/src/effects/effects_for_ledger_request.rs
+++ b/stellar_rust_sdk/src/effects/effects_for_ledger_request.rs
@@ -1,7 +1,9 @@
 use crate::{
     models::{Order, Request},
     BuildQueryParametersExt,
+    Paginatable,
 };
+use stellar_rust_sdk_derive::Pagination;
 
 /// Represents a request to fetch effects associated with a specific ledger from the Stellar Horizon API.
 ///
@@ -11,8 +13,10 @@ use crate::{
 ///
 /// # Example
 /// ```rust
-/// use stellar_rs::effects::effects_for_ledger_request::EffectsForLedgerRequest;
-/// use stellar_rs::models::Order;
+/// # use stellar_rs::effects::effects_for_ledger_request::EffectsForLedgerRequest;
+/// # use stellar_rs::models::Order;
+/// # use stellar_rust_sdk_derive::Pagination;
+/// # use stellar_rs::Paginatable;
 ///
 /// let mut request = EffectsForLedgerRequest::new()
 ///     .set_sequence(125)
@@ -21,7 +25,7 @@ use crate::{
 /// // The request is now ready to be used with a Horizon client to fetch effects for the specified ledger.
 /// ```
 ///
-#[derive(Default)]
+#[derive(Default, Pagination)]
 pub struct EffectsForLedgerRequest {
     /// The ledger's sequence number for which effects are to be retrieved.
     sequence: Option<u32>,
@@ -53,50 +57,6 @@ impl EffectsForLedgerRequest {
     pub fn set_sequence(self, sequence: u32) -> EffectsForLedgerRequest {
         EffectsForLedgerRequest {
             sequence: Some(sequence),
-            ..self
-        }
-    }
-
-    /// Sets the cursor for pagination.
-    ///
-    /// # Arguments
-    /// * `cursor` - A `u32` value pointing to a specific location in a collection of responses.
-    ///
-    pub fn set_cursor(self, cursor: u32) -> Result<EffectsForLedgerRequest, String> {
-        if cursor < 1 {
-            return Err("cursor must be greater than or equal to 1".to_string());
-        }
-
-        Ok(EffectsForLedgerRequest {
-            cursor: Some(cursor),
-            ..self
-        })
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// # Arguments
-    /// * `limit` - A `u8` value specifying the maximum number of records. Range: 1 to 200. Defaults to 10.
-    ///
-    pub fn set_limit(self, limit: u8) -> Result<EffectsForLedgerRequest, String> {
-        if limit < 1 || limit > 200 {
-            return Err("limit must be between 1 and 200".to_string());
-        }
-
-        Ok(EffectsForLedgerRequest {
-            limit: Some(limit),
-            ..self
-        })
-    }
-
-    /// Sets the order of the returned records.
-    ///
-    /// # Arguments
-    /// * `order` - An [`Order`] enum value specifying the order (ascending or descending).
-    ///
-    pub fn set_order(self, order: Order) -> EffectsForLedgerRequest {
-        EffectsForLedgerRequest {
-            order: Some(order),
             ..self
         }
     }

--- a/stellar_rust_sdk/src/effects/effects_for_liquidity_pools_request.rs
+++ b/stellar_rust_sdk/src/effects/effects_for_liquidity_pools_request.rs
@@ -1,5 +1,7 @@
 use crate::models::{Order, Request};
 use crate::BuildQueryParametersExt;
+use crate::Paginatable;
+use stellar_rust_sdk_derive::Pagination;
 
 /// Represents the request to fetch effects for a specific liquidity pool from the Horizon API.
 
@@ -20,8 +22,10 @@ use crate::BuildQueryParametersExt;
 ///
 /// # Example
 /// ```rust
-/// use stellar_rs::effects::effects_for_liquidity_pools_request::EffectsForLiquidityPoolRequest;
-/// use stellar_rs::models::*;
+/// # use stellar_rs::effects::effects_for_liquidity_pools_request::EffectsForLiquidityPoolRequest;
+/// # use stellar_rs::models::*;
+/// # use stellar_rust_sdk_derive::Pagination;
+/// # use stellar_rs::Paginatable;
 ///
 /// let request = EffectsForLiquidityPoolRequest::new()
 ///     .set_liquidity_pool_id("01c58ab8fb283c8b083a26bf2fe06b7b6c6304c13f9d29d956cdf15a48bea72d".to_string())
@@ -32,7 +36,7 @@ use crate::BuildQueryParametersExt;
 /// // The request can now be used with a Horizon client to fetch effects.
 /// ```
 ///
-#[derive(Default)]
+#[derive(Default, Pagination)]
 pub struct EffectsForLiquidityPoolRequest {
     /// The liquidity pool id
     liquidity_pool_id: Option<String>,
@@ -70,50 +74,6 @@ impl EffectsForLiquidityPoolRequest {
             ..self
         }
     }
-
-    /// Sets the cursor for pagination.
-    ///
-    /// # Arguments
-    /// * `cursor` - A `u32` value pointing to a specific location in a collection of responses.
-    ///
-    pub fn set_cursor(self, cursor: u32) -> Result<EffectsForLiquidityPoolRequest, String> {
-        if cursor < 1 {
-            return Err("cursor must be greater than or equal to 1".to_string());
-        }
-
-        Ok(EffectsForLiquidityPoolRequest {
-            cursor: Some(cursor),
-            ..self
-        })
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// # Arguments
-    /// * `limit` - A `u8` value specifying the maximum number of records. Range: 1 to 200. Defaults to 10.
-    ///
-    pub fn set_limit(self, limit: u8) -> Result<EffectsForLiquidityPoolRequest, String> {
-        if limit < 1 || limit > 200 {
-            return Err("limit must be between 1 and 200".to_string());
-        }
-
-        Ok(EffectsForLiquidityPoolRequest {
-            limit: Some(limit),
-            ..self
-        })
-    }
-
-    /// Sets the order of the returned records.
-    ///
-    /// # Arguments
-    /// * `order` - An [`Order`] enum value specifying the order (ascending or descending).
-    ///
-    pub fn set_order(self, order: Order) -> EffectsForLiquidityPoolRequest {
-        EffectsForLiquidityPoolRequest {
-            order: Some(order),
-            ..self
-        }
-    }
 }
 
 impl Request for EffectsForLiquidityPoolRequest {
@@ -143,7 +103,7 @@ impl Request for EffectsForLiquidityPoolRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::BuildQueryParametersExt;
+    use crate::{BuildQueryParametersExt};
 
     #[test]
     fn test_effects_for_liquidity_pools_request() {
@@ -153,7 +113,8 @@ mod tests {
             .unwrap()
             .set_limit(10)
             .unwrap()
-            .set_order(Order::Asc);
+            .set_order(Order::Asc)
+            .unwrap();
 
         let url = request.build_url("https://horizon-testnet.stellar.org");
         let query_parameters = vec![

--- a/stellar_rust_sdk/src/effects/effects_for_operation_request.rs
+++ b/stellar_rust_sdk/src/effects/effects_for_operation_request.rs
@@ -1,7 +1,9 @@
 use crate::{
     models::{Order, Request},
     BuildQueryParametersExt,
+    Paginatable,
 };
+use stellar_rust_sdk_derive::Pagination;
 
 /// Represents the request to fetch the effects for a specific operation from the Horizon API.
 ///
@@ -22,8 +24,10 @@ use crate::{
 ///
 /// # Example
 /// ```rust
-/// use stellar_rs::effects::effects_for_operation_request::EffectsForOperationRequest;
-/// use stellar_rs::models::*;
+/// # use stellar_rs::effects::effects_for_operation_request::EffectsForOperationRequest;
+/// # use stellar_rs::models::*;
+/// # use stellar_rust_sdk_derive::Pagination;
+/// # use stellar_rs::Paginatable;
 ///
 /// let request = EffectsForOperationRequest::new()
 ///     .set_operation_id("123")
@@ -35,7 +39,7 @@ use crate::{
 /// ```
 ///
 
-#[derive(Default)]
+#[derive(Default, Pagination)]
 pub struct EffectsForOperationRequest {
     /// The operation id to filter effects.
     operation_id: Option<String>,
@@ -61,50 +65,6 @@ impl EffectsForOperationRequest {
     pub fn set_operation_id(self, operation_id: &str) -> EffectsForOperationRequest {
         EffectsForOperationRequest {
             operation_id: Some(operation_id.to_string()),
-            ..self
-        }
-    }
-
-    /// Sets the cursor for pagination.
-    ///
-    /// # Arguments
-    /// * `cursor` - A `u32` value pointing to a specific location in a collection of responses.
-    ///
-    pub fn set_cursor(self, cursor: u32) -> Result<EffectsForOperationRequest, String> {
-        if cursor < 1 {
-            return Err("cursor must be greater than or equal to 1".to_string());
-        }
-
-        Ok(EffectsForOperationRequest {
-            cursor: Some(cursor),
-            ..self
-        })
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// # Arguments
-    /// * `limit` - A `u8` value specifying the maximum number of records. Range: 1 to 200. Defaults to 10.
-    ///
-    pub fn set_limit(self, limit: u8) -> Result<EffectsForOperationRequest, String> {
-        if limit < 1 || limit > 200 {
-            return Err("limit must be between 1 and 200".to_string());
-        }
-
-        Ok(EffectsForOperationRequest {
-            limit: Some(limit),
-            ..self
-        })
-    }
-
-    /// Sets the order of the returned records.
-    ///
-    /// # Arguments
-    /// * `order` - An [`Order`] enum value specifying the order (ascending or descending).
-    ///
-    pub fn set_order(self, order: Order) -> EffectsForOperationRequest {
-        EffectsForOperationRequest {
-            order: Some(order),
             ..self
         }
     }
@@ -145,7 +105,8 @@ mod tests {
             .unwrap()
             .set_limit(10)
             .unwrap()
-            .set_order(Order::Asc);
+            .set_order(Order::Asc)
+            .unwrap();
 
         let query_parameters = request.get_query_parameters();
         assert_eq!(

--- a/stellar_rust_sdk/src/effects/effects_for_transaction_request.rs
+++ b/stellar_rust_sdk/src/effects/effects_for_transaction_request.rs
@@ -1,4 +1,5 @@
-use crate::{models::{Order, Request}, BuildQueryParametersExt};
+use crate::{models::{Order, Request}, BuildQueryParametersExt, Paginatable};
+use stellar_rust_sdk_derive::Pagination;
 
 /// Represents a request to fetch effect data from the Stellar Horizon API.
 ///
@@ -13,8 +14,10 @@ use crate::{models::{Order, Request}, BuildQueryParametersExt};
 ///
 /// # Example
 /// ```rust
-/// use stellar_rs::effects::effects_for_transaction_request::EffectForTransactionRequest;
-/// use stellar_rs::models::*;
+/// # use stellar_rs::effects::effects_for_transaction_request::EffectForTransactionRequest;
+/// # use stellar_rs::models::*;
+/// # use stellar_rust_sdk_derive::Pagination;
+/// # use stellar_rs::Paginatable;
 ///
 /// let request = EffectForTransactionRequest::new()
 ///     .set_transaction_hash("transaction_hash".to_string())
@@ -24,7 +27,7 @@ use crate::{models::{Order, Request}, BuildQueryParametersExt};
 ///
 /// // The request can now be used with a Horizon client to fetch effects.
 /// ```
-#[derive(Default)]
+#[derive(Default, Pagination)]
 pub struct EffectForTransactionRequest {
     /// The transaction hash of the transaction of the effect
     transaction_hash: Option<String>,
@@ -59,50 +62,6 @@ impl EffectForTransactionRequest {
     ) -> EffectForTransactionRequest {
         EffectForTransactionRequest {
             transaction_hash: Some(transaction_hash),
-            ..self
-        }
-    }
-
-    /// Sets the cursor for pagination.
-    ///
-    /// # Arguments
-    /// * `cursor` - A `u32` value pointing to a specific location in a collection of responses.
-    ///
-    pub fn set_cursor(self, cursor: u32) -> Result<EffectForTransactionRequest, String> {
-        if cursor < 1 {
-            return Err("cursor must be greater than or equal to 1".to_string());
-        }
-
-        Ok(EffectForTransactionRequest {
-            cursor: Some(cursor),
-            ..self
-        })
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// # Arguments
-    /// * `limit` - A `u8` value specifying the maximum number of records. Range: 1 to 200. Defaults to 10.
-    ///
-    pub fn set_limit(self, limit: u8) -> Result<EffectForTransactionRequest, String> {
-        if limit < 1 || limit > 200 {
-            return Err("limit must be between 1 and 200".to_string());
-        }
-
-        Ok(EffectForTransactionRequest {
-            limit: Some(limit),
-            ..self
-        })
-    }
-
-    /// Sets the order of the returned records.
-    ///
-    /// # Arguments
-    /// * `order` - An [`Order`] enum value specifying the order (ascending or descending).
-    ///
-    pub fn set_order(self, order: Order) -> EffectForTransactionRequest {
-        EffectForTransactionRequest {
-            order: Some(order),
             ..self
         }
     }
@@ -144,7 +103,8 @@ mod tests {
             .unwrap()
             .set_limit(10)
             .unwrap()
-            .set_order(Order::Asc);
+            .set_order(Order::Asc)
+            .unwrap();
 
         let url = request.build_url("https://horizon-testnet.stellar.org");
         let query_parameters = vec![

--- a/stellar_rust_sdk/src/effects/mod.rs
+++ b/stellar_rust_sdk/src/effects/mod.rs
@@ -21,7 +21,7 @@ pub mod prelude {
 #[cfg(test)]
 mod tests {
     use super::prelude::*;
-    use crate::horizon_client::HorizonClient;
+    use crate::{horizon_client::HorizonClient, Paginatable};
 
     #[test]
     fn dummy_test() {

--- a/stellar_rust_sdk/src/horizon_client.rs
+++ b/stellar_rust_sdk/src/horizon_client.rs
@@ -566,6 +566,8 @@ impl HorizonClient {
     /// # use stellar_rs::ledgers::prelude::*;
     /// # use stellar_rs::models::Request;
     /// # use stellar_rs::horizon_client::HorizonClient;
+    /// # use stellar_rust_sdk_derive::Pagination;
+    /// # use stellar_rs::Paginatable;
     /// #
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
@@ -674,6 +676,8 @@ impl HorizonClient {
     /// # use stellar_rs::effects::prelude::*;
     /// # use stellar_rs::models::Request;
     /// # use stellar_rs::horizon_client::HorizonClient;
+    /// # use stellar_rust_sdk_derive::Pagination;
+    /// # use crate::stellar_rs::Paginatable;
     /// #
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
@@ -728,6 +732,8 @@ impl HorizonClient {
     /// # use stellar_rs::effects::prelude::*;
     /// # use stellar_rs::models::Request;
     /// # use stellar_rs::horizon_client::HorizonClient;
+    /// # use stellar_rust_sdk_derive::Pagination;
+    /// # use stellar_rs::Paginatable;
     ///
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
@@ -950,6 +956,8 @@ impl HorizonClient {
     /// # use stellar_rs::operations::prelude::*;
     /// # use stellar_rs::models::Request;
     /// # use stellar_rs::horizon_client::HorizonClient;
+    /// # use stellar_rust_sdk_derive::Pagination;
+    /// # use stellar_rs::Paginatable;
     /// #
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();

--- a/stellar_rust_sdk/src/ledgers/ledgers_request.rs
+++ b/stellar_rust_sdk/src/ledgers/ledgers_request.rs
@@ -1,4 +1,5 @@
-use crate::{models::*, BuildQueryParametersExt};
+use crate::{models::*, BuildQueryParametersExt, Paginatable};
+use stellar_rust_sdk_derive::Pagination;
 
 /// Represents a request to fetch ledger data from the Stellar Horizon API.
 ///
@@ -13,18 +14,20 @@ use crate::{models::*, BuildQueryParametersExt};
 ///
 /// # Example
 /// ```rust
-/// use stellar_rs::ledgers::ledgers_request::LedgersRequest;
-/// use stellar_rs::models::*;
+/// # use stellar_rs::ledgers::ledgers_request::LedgersRequest;
+/// # use stellar_rs::models::*;
+/// # use stellar_rust_sdk_derive::Pagination;
+/// # use stellar_rs::Paginatable;
 ///
 /// let request = LedgersRequest::new()
 ///     .set_cursor(1234).unwrap()
 ///     .set_limit(20).unwrap()
-///     .set_order(Order::Desc);
+///     .set_order(Order::Desc).unwrap();
 ///
 /// // The request can now be used with a Horizon client to fetch ledgers.
 /// ```
 ///
-#[derive(Default)]
+#[derive(Default, Pagination)]
 pub struct LedgersRequest {
     /// A pointer to a specific location in a collection of responses, derived from the
     ///   `paging_token` value of a record. Used for pagination control in the API response.
@@ -43,50 +46,6 @@ impl LedgersRequest {
     /// Creates a new `LedgersRequest` with default parameters.
     pub fn new() -> Self {
         LedgersRequest::default()
-    }
-
-    /// Sets the cursor for pagination.
-    ///
-    /// # Arguments
-    /// * `cursor` - A `u32` value pointing to a specific location in a collection of responses.
-    ///
-    pub fn set_cursor(self, cursor: u32) -> Result<LedgersRequest, String> {
-        if cursor < 1 {
-            return Err("cursor must be greater than or equal to 1".to_string());
-        }
-
-        Ok(LedgersRequest {
-            cursor: Some(cursor),
-            ..self
-        })
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// # Arguments
-    /// * `limit` - A `u8` value specifying the maximum number of records. Range: 1 to 200. Defaults to 10.
-    ///
-    pub fn set_limit(self, limit: u8) -> Result<LedgersRequest, String> {
-        if limit < 1 || limit > 200 {
-            return Err("limit must be between 1 and 200".to_string());
-        }
-
-        Ok(LedgersRequest {
-            limit: Some(limit),
-            ..self
-        })
-    }
-
-    /// Sets the order of the returned records.
-    ///
-    /// # Arguments
-    /// * `order` - An [`Order`] enum value specifying the order (ascending or descending).
-    ///
-    pub fn set_order(self, order: Order) -> LedgersRequest {
-        LedgersRequest {
-            order: Some(order),
-            ..self
-        }
     }
 }
 

--- a/stellar_rust_sdk/src/ledgers/mod.rs
+++ b/stellar_rust_sdk/src/ledgers/mod.rs
@@ -69,7 +69,7 @@ static LEDGERS_PATH: &str = "ledgers";
 ///
 /// ```rust
 /// // Import the contents of the ledgers prelude
-/// use stellar_rs::ledgers::prelude::*;
+/// # use stellar_rs::ledgers::prelude::*;
 ///
 /// // This allows for direct usage of LedgersRequest, SingleLedgerResponse, etc.
 /// let ledger_request = LedgersRequest::new();
@@ -85,7 +85,7 @@ pub mod prelude {
 #[cfg(test)]
 pub mod tests {
     use super::prelude::*;
-    use crate::horizon_client::HorizonClient;
+    use crate::{horizon_client::HorizonClient, Paginatable};
     use base64::{engine::general_purpose, Engine};
 
     #[tokio::test]

--- a/stellar_rust_sdk/src/lib.rs
+++ b/stellar_rust_sdk/src/lib.rs
@@ -249,9 +249,11 @@ pub mod horizon_client;
 /// response struct, like `SingleLedgerResponse` or `AllLedgersResponse`.
 ///
 /// ```rust
-/// use stellar_rs::horizon_client::HorizonClient;
-/// use stellar_rs::ledgers::prelude::*;
-/// use stellar_rs::models::Request;
+/// # use stellar_rs::horizon_client::HorizonClient;
+/// # use stellar_rs::ledgers::prelude::*;
+/// # use stellar_rs::models::Request;
+/// # use stellar_rust_sdk_derive::Pagination;
+/// # use stellar_rs::Paginatable;
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let horizon_client = HorizonClient::new("https://horizon-testnet.stellar.org".to_string())?;
@@ -290,9 +292,11 @@ pub mod ledgers;
 /// response struct, like `SingleEffectResponse` or `AllEffectsResponse`.
 ///
 /// ```rust
-/// use stellar_rs::horizon_client::HorizonClient;
-/// use stellar_rs::effects::prelude::*;
-/// use stellar_rs::models::Request;
+/// # use stellar_rs::horizon_client::HorizonClient;
+/// # use stellar_rs::effects::prelude::*;
+/// # use stellar_rs::models::Request;
+/// # use stellar_rust_sdk_derive::Pagination;
+/// # use crate::stellar_rs::Paginatable;
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let horizon_client = HorizonClient::new("https://horizon-testnet.stellar.org".to_string())?;
@@ -407,9 +411,11 @@ pub mod offers;
 /// response struct, like `SingleOperationResponse` or `AllOperationsResponse`.
 ///
 /// ```rust
-/// use stellar_rs::horizon_client::HorizonClient;
-/// use stellar_rs::operations::prelude::*;
-/// use stellar_rs::models::Request;
+/// # use stellar_rs::horizon_client::HorizonClient;
+/// # use stellar_rs::operations::prelude::*;
+/// # use stellar_rs::models::Request;
+/// # use stellar_rust_sdk_derive::Pagination;
+/// # use stellar_rs::Paginatable;
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let horizon_client = HorizonClient::new("https://horizon-testnet.stellar.org".to_string())?;

--- a/stellar_rust_sdk/src/liquidity_pools/all_liquidity_pools_request.rs
+++ b/stellar_rust_sdk/src/liquidity_pools/all_liquidity_pools_request.rs
@@ -1,4 +1,5 @@
-use crate::{models::{Order, Request}, BuildQueryParametersExt};
+use crate::{models::{Order, Request}, BuildQueryParametersExt, Paginatable};
+use stellar_rust_sdk_derive::Pagination;
 
 /// Represents a reserve for a liquidity pool. This struct is used to specify the asset code and
 #[derive(PartialEq, Debug)]
@@ -30,20 +31,22 @@ pub enum ReserveType {
 ///
 /// # Example
 /// ```rust
-/// use stellar_rs::liquidity_pools::all_liquidity_pools_request::AllLiquidityPoolsRequest;
-/// use stellar_rs::models::*;
+/// # use stellar_rs::liquidity_pools::all_liquidity_pools_request::AllLiquidityPoolsRequest;
+/// # use stellar_rs::models::*;
+/// # use stellar_rust_sdk_derive::Pagination;
+/// # use stellar_rs::Paginatable;
 ///
 /// let request = AllLiquidityPoolsRequest::new()
-///     .set_cursor(1234)
-///     .set_limit(20)
-///     .set_order(Order::Desc)
+///     .set_cursor(1234).unwrap()
+///     .set_limit(20).unwrap()
+///     .set_order(Order::Desc).unwrap()
 ///     .add_native_reserve()
 ///     .add_alphanumeric4_reserve("USD".to_string(), "GAXLYH...".to_string());
 ///
 /// // The request can now be used with a Horizon client to fetch liquidity pools.
 /// ```
 ///
-#[derive(Default)]
+#[derive(Default, Pagination)]
 pub struct AllLiquidityPoolsRequest {
     /// A pointer to a specific location in a collection of responses, derived from the
     ///   `paging_token` value of a record. Used for pagination control in the API response.
@@ -69,42 +72,6 @@ impl AllLiquidityPoolsRequest {
             limit: None,
             order: None,
             reserves: None,
-        }
-    }
-
-    /// Sets the cursor for pagination.
-    ///
-    /// # Arguments
-    /// * `cursor` - A `u32` value pointing to a specific location in a collection of responses.
-    ///
-    pub fn set_cursor(self, cursor: u32) -> AllLiquidityPoolsRequest {
-        AllLiquidityPoolsRequest {
-            cursor: Some(cursor),
-            ..self
-        }
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// # Arguments
-    /// * `limit` - A `u8` value specifying the maximum number of records. Range: 1 to 200. Defaults to 10.
-    ///
-    pub fn set_limit(self, limit: u8) -> AllLiquidityPoolsRequest {
-        AllLiquidityPoolsRequest {
-            limit: Some(limit),
-            ..self
-        }
-    }
-
-    /// Sets the order of the returned records.
-    ///
-    /// # Arguments
-    /// * `order` - An [`Order`] enum value specifying the order (ascending or descending).
-    ///
-    pub fn set_order(self, order: Order) -> AllLiquidityPoolsRequest {
-        AllLiquidityPoolsRequest {
-            order: Some(order),
-            ..self
         }
     }
 
@@ -217,7 +184,7 @@ impl Request for AllLiquidityPoolsRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
-
+    
     #[test]
     fn test_new() {
         let request = AllLiquidityPoolsRequest::new();
@@ -229,19 +196,19 @@ mod tests {
 
     #[test]
     fn test_set_cursor() {
-        let request = AllLiquidityPoolsRequest::new().set_cursor(1234);
+        let request = AllLiquidityPoolsRequest::new().set_cursor(1234).unwrap();
         assert_eq!(request.cursor, Some(1234));
     }
 
     #[test]
     fn test_set_limit() {
-        let request = AllLiquidityPoolsRequest::new().set_limit(20);
+        let request = AllLiquidityPoolsRequest::new().set_limit(20).unwrap();
         assert_eq!(request.limit, Some(20));
     }
 
     #[test]
     fn test_set_order() {
-        let request = AllLiquidityPoolsRequest::new().set_order(Order::Desc);
+        let request = AllLiquidityPoolsRequest::new().set_order(Order::Desc).unwrap();
         assert_eq!(request.order, Some(Order::Desc));
     }
 

--- a/stellar_rust_sdk/src/liquidity_pools/mod.rs
+++ b/stellar_rust_sdk/src/liquidity_pools/mod.rs
@@ -10,10 +10,10 @@ pub mod prelude {
 }
 
 #[tokio::test]
-
 async fn test_get_all_liquidity_pools() {
-    use crate::horizon_client::HorizonClient;
+    use crate::{horizon_client::HorizonClient, Paginatable};
     use all_liquidity_pools_request::AllLiquidityPoolsRequest;
+
 
     const RSP_1_LIQUIDITY_POOL_ID: &str =
         "4cd1f6defba237eecbc5fefe259f89ebc4b5edd49116beb5536c4034fc48d63f";
@@ -64,7 +64,8 @@ async fn test_get_all_liquidity_pools() {
             "USDC".to_string(),
             "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5".to_string(),
         )
-        .set_limit(2);
+        .set_limit(2)
+        .unwrap();
 
     let all_liquidity_pools_response_1 = horizon_client
         .get_all_liquidity_pools(&all_liquidity_pools_request_1)
@@ -113,7 +114,8 @@ async fn test_get_all_liquidity_pools() {
             "NOODLE".to_string(),
             "GARPXPHGABTN52WPJ2QZQBY7TSXMK7PXLKOD6FSPA2TEVSJDWIDRSHPO".to_string(),
         )
-        .set_limit(2);
+        .set_limit(2)
+        .unwrap();
 
     let all_liquidity_pools_response_2 = horizon_client
         .get_all_liquidity_pools(&all_liquidity_pools_request_2)
@@ -167,7 +169,8 @@ async fn test_get_all_liquidity_pools() {
             "LPA7".to_string(),
             "GDTCZZNMT74SEGPDQL3IQJDJ54MXQJHSNQ3HNNJJIJLIVG2LOSDLG2OZ".to_string(),
         )
-        .set_limit(2);
+        .set_limit(2)
+            .unwrap();
 
     let all_liquidity_pools_response_3 = horizon_client
         .get_all_liquidity_pools(&all_liquidity_pools_request_3)

--- a/stellar_rust_sdk/src/offers/mod.rs
+++ b/stellar_rust_sdk/src/offers/mod.rs
@@ -190,12 +190,12 @@ pub mod test {
         const BUYING_ASSET_TYPE: &str = "credit_alphanum12";
         const BUYING_ASSET_CODE: &str = "EURCAllow";
         const BUYING_ASSET_ISSUER: &str = "GA6HVGLFUF3BHHGR5CMYXIVZ3RYVUH5EUYAOAY4T3OKI5OQVIWVRK24R";
-        const AMOUNT: &str = "922320116339.8175807";
+        const AMOUNT: &str = "922278138224.9775807";
         const PRICE_R_N: &u32 = &1;
         const PRICE_R_D: &u32 = &1;
         const PRICE: &str = "1.0000000";
-        const LAST_MODIFIED_LEDGER: &u32 = &1526957;
-        const LAST_MODIFIED_TIME: &str = "2024-05-09T14:38:06Z";
+        const LAST_MODIFIED_LEDGER: &u32 = &1762248;
+        const LAST_MODIFIED_TIME: &str = "2024-05-23T22:12:07Z";
     
         let horizon_client =
             HorizonClient::new("https://horizon-testnet.stellar.org"

--- a/stellar_rust_sdk/src/operations/all_operations_request.rs
+++ b/stellar_rust_sdk/src/operations/all_operations_request.rs
@@ -1,6 +1,8 @@
 use crate::models::{IncludeFailed, Order, Request};
+use crate::Paginatable;
+use stellar_rust_sdk_derive::Pagination;
 
-#[derive(Default)]
+#[derive(Default, Pagination)]
 pub struct AllOperationsRequest {
     /// A pointer to a specific location in a collection of responses, derived from the
     ///   `paging_token` value of a record. Used for pagination control in the API response.
@@ -21,50 +23,6 @@ pub struct AllOperationsRequest {
 impl AllOperationsRequest {
     pub fn new() -> Self {
         AllOperationsRequest::default()
-    }
-
-    /// Sets the cursor for pagination.
-    ///
-    /// # Arguments
-    /// * `cursor` - A `u32` value pointing to a specific location in a collection of responses.
-    ///
-    pub fn set_cursor(self, cursor: u32) -> Result<AllOperationsRequest, String> {
-        if cursor < 1 {
-            return Err("cursor must be greater than or equal to 1".to_string());
-        }
-
-        Ok(AllOperationsRequest {
-            cursor: Some(cursor),
-            ..self
-        })
-    }
-
-    /// Sets the maximum number of records to return.
-    ///
-    /// # Arguments
-    /// * `limit` - A `u8` value specifying the maximum number of records. Range: 1 to 200. Defaults to 10.
-    ///
-    pub fn set_limit(self, limit: u8) -> Result<AllOperationsRequest, String> {
-        if limit < 1 || limit > 200 {
-            return Err("limit must be between 1 and 200".to_string());
-        }
-
-        Ok(AllOperationsRequest {
-            limit: Some(limit),
-            ..self
-        })
-    }
-
-    /// Sets the order of the returned records.
-    ///
-    /// # Arguments
-    /// * `order` - An [`Order`] enum value specifying the order (ascending or descending).
-    ///
-    pub fn set_order(self, order: Order) -> AllOperationsRequest {
-        AllOperationsRequest {
-            order: Some(order),
-            ..self
-        }
     }
 
     /// Sets whether to include failed operations in the response.
@@ -120,6 +78,7 @@ mod tests {
             .set_limit(10)
             .unwrap()
             .set_order(Order::Desc)
+            .unwrap()
             .set_include_failed(IncludeFailed::True);
 
         assert_eq!(

--- a/stellar_rust_sdk/src/order_book/mod.rs
+++ b/stellar_rust_sdk/src/order_book/mod.rs
@@ -14,9 +14,9 @@ pub mod tests {
 
     #[tokio::test]
     async fn get_order_bookdetails() {
-        const BIDS_N: &u32 = &1000;
-        const BIDS_D: &u32 = &87;
-        const BIDS_PRICE: &str = "11.4942529";
+        const BIDS_N: &u32 = &250000;
+        const BIDS_D: &u32 = &21749;
+        const BIDS_PRICE: &str = "11.4947814";
         const BIDS_AMOUNT: &str = "2556626.8467920";
 
         const ASKS_N: &u32 = &2299;

--- a/stellar_rust_sdk_derive/src/lib.rs
+++ b/stellar_rust_sdk_derive/src/lib.rs
@@ -12,6 +12,10 @@ pub fn pagination_macro(input: TokenStream) -> TokenStream {
         impl Paginatable for #struct_name {
             fn set_cursor(self, cursor: u32) -> Result<Self, String> {
                 // Always accept the cursor since it's non-optional in the setter
+                if cursor < 1 {
+                    return Err("Cursor must be greater than or equal to 1.".to_string());
+                }
+
                 Ok(Self { cursor: Some(cursor), ..self })
             }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes #59.

- Applies the pagination macro in all endpoints (except accounts, see below), and removes duplicate code. Some tests needed to be updated slightly (for example, `unwrap` needed to be appended in some locations.

- Adds a check in the pagination macro itself (`set_cursor`), which was previously present in some pagination implementations. This way, one uniform error message will always be returned.

- Updates relevant documentation examples with the addition of required crate imports for the macro.

Note: *Accounts endpoint* still needs to be refactored, but the pagination macro needs to be updated first, due to generics. See #70.

### :arrow_heading_down: What is the current behavior?
Similar implementations of pagination functionality are present in some endpoints, which results in duplicate code. Also, there are minor differences between these implementation, leading to inconsistencies.

### :new: What is the new behavior (if this is a feature change)?
Common code for pagination is injected with a derive macro, rather than implemented wherever required.

### :boom: Does this PR introduce a breaking change?
No.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current main
