### PR TITLE
Add support for generics in pagination macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Badges
 
 ![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/Baseflow/stellar-rust-sdk/.github%2Fworkflows%2Fcargo-build-and-test.yaml)
-[![Crates.io](https://img.shields.io/crates/v/stellar-sdk.svg)](https://crates.io/crates/stellar-sdk)
+[![Crates.io](https://img.shields.io/crates/v/stellar-sdk.svg)](https://crates.io/crates/stellar-rs)
 [![Documentation](https://img.shields.io/badge/documentation-1)](https://docs.rs/stellar-rs/latest/stellar_rs/index.html)
 [![GitHub issues](https://img.shields.io/github/issues/Baseflow/stellar-rust-sdk)]()
 [![GitHub stars](https://img.shields.io/github/stars/Baseflow/stellar-rust-sdk)]()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes #70. Modifies the pagination derive macro to account for generics in structs.

### :arrow_heading_down: What is the current behavior?
The compiler throws a cryptic and unhelpful error when trying to apply the pagination macro to a struct with generics. This is because the macro previously didn't handle generics.

### :new: What is the new behavior (if this is a feature change)?
Structs with generics can now also be used. Behaviour for structs without generics remain unchanged.

### :boom: Does this PR introduce a breaking change?
No.

### :memo: Links to relevant issues/docs
[https://docs.rs/syn/latest/syn/struct.Generics.html](https://docs.rs/syn/latest/syn/struct.Generics.html)

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current main
