### PR TITLE
Rename `Links` structs

### DIFF
--- a/stellar_rust_sdk/src/claimable_balances/response.rs
+++ b/stellar_rust_sdk/src/claimable_balances/response.rs
@@ -26,7 +26,7 @@ pub struct AllClaimableBalancesResponse {
 pub struct ClaimableBalance {
     /// Links to related resources in the Horizon API response.
     #[serde(rename = "_links")]
-    pub links: Links,
+    pub links: ClaimableBalanceLinks,
 
     /// The unique identifier of the claimable balance.
     pub id: String,
@@ -62,7 +62,7 @@ pub struct ClaimableBalance {
 /// Contains navigational links related to the single claimable balance response.
 #[derive(Default, Debug, Clone, Serialize, Deserialize, Getters)]
 #[serde(rename_all = "camelCase")]
-pub struct Links {
+pub struct ClaimableBalanceLinks {
     /// The link to the current claimable balance resource.
     #[serde(rename = "self")]
     pub self_field: Link,

--- a/stellar_rust_sdk/src/offers/mod.rs
+++ b/stellar_rust_sdk/src/offers/mod.rs
@@ -190,12 +190,12 @@ pub mod test {
         const BUYING_ASSET_TYPE: &str = "credit_alphanum12";
         const BUYING_ASSET_CODE: &str = "EURCAllow";
         const BUYING_ASSET_ISSUER: &str = "GA6HVGLFUF3BHHGR5CMYXIVZ3RYVUH5EUYAOAY4T3OKI5OQVIWVRK24R";
-        const AMOUNT: &str = "922278138224.9775807";
+        const AMOUNT: &str = "922274722883.0675807";
         const PRICE_R_N: &u32 = &1;
         const PRICE_R_D: &u32 = &1;
         const PRICE: &str = "1.0000000";
-        const LAST_MODIFIED_LEDGER: &u32 = &1762248;
-        const LAST_MODIFIED_TIME: &str = "2024-05-23T22:12:07Z";
+        const LAST_MODIFIED_LEDGER: &u32 = &1938375;
+        const LAST_MODIFIED_TIME: &str = "2024-06-03T15:21:13Z";
     
         let horizon_client =
             HorizonClient::new("https://horizon-testnet.stellar.org"

--- a/stellar_rust_sdk/src/offers/response.rs
+++ b/stellar_rust_sdk/src/offers/response.rs
@@ -60,7 +60,7 @@ pub struct PriceR {
 /// and the offer maker.
 ///
 #[derive(Debug, Deserialize, Serialize, Clone, Getters)]
-pub struct Links {
+pub struct OfferResponseLinks {
     /// The link to the offer itself.
     #[serde(rename = "self")]
     self_link: Link,
@@ -78,7 +78,7 @@ pub struct Links {
 pub struct OfferResponse {
     /// Navigational links related to the offer.
     #[serde(rename = "_links")]
-    links: Links,
+    links: OfferResponseLinks,
     /// The unique identifier for the offer.
     id: String,
     /// A token used for paging through results.


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes #75. Give ambiguously named structs unique and context appropriate names. Previously, some structs were named `Links`. This can potentially cause naming conflicts.

### :boom: Does this PR introduce a breaking change?
No.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current main
