### PR TITLE
Add documentation to fee stats endpoint

### DIFF
--- a/stellar_rust_sdk/src/fee_stats/mod.rs
+++ b/stellar_rust_sdk/src/fee_stats/mod.rs
@@ -1,6 +1,29 @@
+/// Provides the `FeeStatsRequest`.
+///
+/// This module provides the `FeeStatsRequest` struct, specifically designed for
+/// constructing requests to query information about fee stats from the Horizon
+/// server. It is tailored for use with the [`HorizonClient::get_fee_stats`](crate::horizon_client::HorizonClient::get_fee_stats)
+/// method.
+///
 pub mod fee_stats_request;
+
+/// Provides the responses.
+///
+/// This module defines structures representing the response from the Horizon API when querying
+/// for fee stats. The structures are designed to deserialize the JSON response into Rust
+/// objects, enabling straightforward access to various details of a single Stellar account.
+///
+/// These structures are equipped with serialization capabilities to handle the JSON data from the
+/// Horizon server and with getter methods for easy field access.
+///
 pub mod response;
 
+/// The base path for fee stats related endpoints in the Horizon API.
+///
+/// # Usage
+/// This variable is intended to be used internally by the request-building logic
+/// to ensure consistent and accurate path construction for fee stats related API calls.
+///
 static FEE_STATS_PATH: &str = "fee_stats";
 
 pub mod prelude {

--- a/stellar_rust_sdk/src/offers/mod.rs
+++ b/stellar_rust_sdk/src/offers/mod.rs
@@ -190,12 +190,12 @@ pub mod test {
         const BUYING_ASSET_TYPE: &str = "credit_alphanum12";
         const BUYING_ASSET_CODE: &str = "EURCAllow";
         const BUYING_ASSET_ISSUER: &str = "GA6HVGLFUF3BHHGR5CMYXIVZ3RYVUH5EUYAOAY4T3OKI5OQVIWVRK24R";
-        const AMOUNT: &str = "922278138224.9775807";
+        const AMOUNT: &str = "922274722883.0675807";
         const PRICE_R_N: &u32 = &1;
         const PRICE_R_D: &u32 = &1;
         const PRICE: &str = "1.0000000";
-        const LAST_MODIFIED_LEDGER: &u32 = &1762248;
-        const LAST_MODIFIED_TIME: &str = "2024-05-23T22:12:07Z";
+        const LAST_MODIFIED_LEDGER: &u32 = &1938375;
+        const LAST_MODIFIED_TIME: &str = "2024-06-03T15:21:13Z";
     
         let horizon_client =
             HorizonClient::new("https://horizon-testnet.stellar.org"


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes #61. Adds documentation for all endpoints in the fee stats endpoint group. 

### :boom: Does this PR introduce a breaking change?
No.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current main
