### PR TITLE
'Get' endpoints for transactions

### DIFF
--- a/stellar_rust_sdk/src/horizon_client.rs
+++ b/stellar_rust_sdk/src/horizon_client.rs
@@ -1653,11 +1653,15 @@ impl HorizonClient {
     ) -> Result<AllTransactionsResponse, String> {
         self.get::<AllTransactionsResponse>(request).await
     }
-}
     
-
-
-
+    // TODO: Documentation
+    pub async fn get_transactions_for_ledger(
+        &self,
+        request: &TransactionsForLedgerRequest<TransactionsLedgerId>,
+    ) -> Result<AllTransactionsResponse, String> {
+        self.get::<AllTransactionsResponse>(request).await
+    }
+}
 
 /// Handles the response received from an HTTP request made to the Horizon server.
 ///

--- a/stellar_rust_sdk/src/horizon_client.rs
+++ b/stellar_rust_sdk/src/horizon_client.rs
@@ -1646,7 +1646,52 @@ impl HorizonClient {
         self.get::<AllTransactionsResponse>(request).await
     }
     
-    // TODO: Documentation
+    /// Retrieves a list of all transactions for a given account from the Horizon server.
+    ///
+    /// This asynchronous method fetches a list of all transactions for a given account from
+    /// the Horizon server. It requires an [`TransactionsForAccountRequest`] to specify the optional query parameters.
+    ///
+    /// # Arguments
+    /// * `request` - A reference to an [`TransactionsForAccountRequest`] instance, containing the
+    /// parameters for the transactions request.
+    ///
+    /// # Returns
+    ///
+    /// On successful execution, returns a `Result` containing an [`AllTransactionsResponse`], which includes
+    /// the list of all transactions obtained from the Horizon server. If the request fails, it returns an error within `Result`.
+    ///
+    /// # Usage
+    /// To use this method, create an instance of [`TransactionsForAccountRequest`] and set any desired
+    /// filters or parameters.
+    ///
+    /// ```
+    /// # use stellar_rs::transactions::prelude::*;
+    /// # use stellar_rs::models::Request;
+    /// # use stellar_rs::horizon_client::HorizonClient;
+    /// # use stellar_rust_sdk_derive::Pagination;
+    /// # use stellar_rs::Paginatable;
+    /// #
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
+    /// # let horizon_client = HorizonClient::new(base_url)
+    /// #    .expect("Failed to create Horizon Client");
+    /// let request = TransactionsForAccountRequest::new()
+    ///     .set_account_id("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H".to_string()).unwrap()
+    ///     .set_include_failed(true).unwrap();
+    ///
+    /// let response = horizon_client.get_transactions_for_account(&request).await;
+    ///
+    /// // Access the transactions
+    /// if let Ok(transactions_response) = response {
+    ///     for transaction in transactions_response.embedded().records() {
+    ///         println!("Transaction ID: {}", transaction.id());
+    ///         // Further processing...
+    ///     }
+    /// }
+    /// # Ok({})
+    /// # }
+    /// ```
+    ///
     pub async fn get_transactions_for_account(
         &self,
         request: &TransactionsForAccountRequest<TransactionsAccountId>,
@@ -1654,7 +1699,52 @@ impl HorizonClient {
         self.get::<AllTransactionsResponse>(request).await
     }
     
-    // TODO: Documentation
+    /// Retrieves a list of all transactions in a given ledger from the Horizon server.
+    ///
+    /// This asynchronous method fetches a list of all transactions in a given ledger from
+    /// the Horizon server. It requires an [`TransactionsForLedgerRequest`] to specify the optional query parameters.
+    ///
+    /// # Arguments
+    /// * `request` - A reference to an [`TransactionsForLedgerRequest`] instance, containing the
+    /// parameters for the transactions request.
+    ///
+    /// # Returns
+    ///
+    /// On successful execution, returns a `Result` containing an [`AllTransactionsResponse`], which includes
+    /// the list of all transactions obtained from the Horizon server. If the request fails, it returns an error within `Result`.
+    ///
+    /// # Usage
+    /// To use this method, create an instance of [`TransactionsForLedgerRequest`] and set any desired
+    /// filters or parameters.
+    ///
+    /// ```
+    /// # use stellar_rs::transactions::prelude::*;
+    /// # use stellar_rs::models::Request;
+    /// # use stellar_rs::horizon_client::HorizonClient;
+    /// # use stellar_rust_sdk_derive::Pagination;
+    /// # use stellar_rs::Paginatable;
+    /// #
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
+    /// # let horizon_client = HorizonClient::new(base_url)
+    /// #    .expect("Failed to create Horizon Client");
+    /// let request = TransactionsForLedgerRequest::new()
+    ///     .set_ledger_sequence("539".to_string()).unwrap()
+    ///     .set_include_failed(true).unwrap();
+    ///
+    /// let response = horizon_client.get_transactions_for_ledger(&request).await;
+    ///
+    /// // Access the transactions
+    /// if let Ok(transactions_response) = response {
+    ///     for transaction in transactions_response.embedded().records() {
+    ///         println!("Transaction ID: {}", transaction.id());
+    ///         // Further processing...
+    ///     }
+    /// }
+    /// # Ok({})
+    /// # }
+    /// ```
+    ///
     pub async fn get_transactions_for_ledger(
         &self,
         request: &TransactionsForLedgerRequest<TransactionsLedgerId>,
@@ -1662,7 +1752,52 @@ impl HorizonClient {
         self.get::<AllTransactionsResponse>(request).await
     }
 
-    // TODO: Documentation
+    /// Retrieves a list of all transactions referencing a given liquidity pool from the Horizon server.
+    ///
+    /// This asynchronous method fetches a list of all transactions referencing a given liquidity pool from
+    /// the Horizon server. It requires an [`TransactionsForLiquidityPoolRequest`] to specify the optional query parameters.
+    ///
+    /// # Arguments
+    /// * `request` - A reference to an [`TransactionsForLiquidityPoolRequest`] instance, containing the
+    /// parameters for the transactions request.
+    ///
+    /// # Returns
+    ///
+    /// On successful execution, returns a `Result` containing an [`AllTransactionsResponse`], which includes
+    /// the list of all transactions obtained from the Horizon server. If the request fails, it returns an error within `Result`.
+    ///
+    /// # Usage
+    /// To use this method, create an instance of [`TransactionsForLiquidityPoolRequest`] and set any desired
+    /// filters or parameters.
+    ///
+    /// ```
+    /// # use stellar_rs::transactions::prelude::*;
+    /// # use stellar_rs::models::Request;
+    /// # use stellar_rs::horizon_client::HorizonClient;
+    /// # use stellar_rust_sdk_derive::Pagination;
+    /// # use stellar_rs::Paginatable;
+    /// #
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
+    /// # let horizon_client = HorizonClient::new(base_url)
+    /// #    .expect("Failed to create Horizon Client");
+    /// let request = TransactionsForLiquidityPoolRequest::new()
+    ///     .set_liquidity_pool_id("0066b15f5d0dc0be771209c33f3e4126383e58183a598eae8b3813024c6a6d10".to_string()).unwrap()
+    ///     .set_include_failed(true).unwrap();
+    ///
+    /// let response = horizon_client.get_transactions_for_liquidity_pool(&request).await;
+    ///
+    /// // Access the transactions
+    /// if let Ok(transactions_response) = response {
+    ///     for transaction in transactions_response.embedded().records() {
+    ///         println!("Transaction ID: {}", transaction.id());
+    ///         // Further processing...
+    ///     }
+    /// }
+    /// # Ok({})
+    /// # }
+    /// ```
+    ///
     pub async fn get_transactions_for_liquidity_pool(
         &self,
         request: &TransactionsForLiquidityPoolRequest<TransactionsLiquidityPoolId>,

--- a/stellar_rust_sdk/src/horizon_client.rs
+++ b/stellar_rust_sdk/src/horizon_client.rs
@@ -1661,6 +1661,14 @@ impl HorizonClient {
     ) -> Result<AllTransactionsResponse, String> {
         self.get::<AllTransactionsResponse>(request).await
     }
+
+    // TODO: Documentation
+    pub async fn get_transactions_for_liquidity_pool(
+        &self,
+        request: &TransactionsForLiquidityPoolRequest<TransactionsLiquidityPoolId>,
+    ) -> Result<AllTransactionsResponse, String> {
+        self.get::<AllTransactionsResponse>(request).await
+    }
 }
 
 /// Handles the response received from an HTTP request made to the Horizon server.

--- a/stellar_rust_sdk/src/horizon_client.rs
+++ b/stellar_rust_sdk/src/horizon_client.rs
@@ -1645,7 +1645,19 @@ impl HorizonClient {
     ) -> Result<AllTransactionsResponse, String> {
         self.get::<AllTransactionsResponse>(request).await
     }
+    
+    // TODO: Documentation
+    pub async fn get_transactions_for_account(
+        &self,
+        request: &TransactionsForAccountRequest<TransactionsAccountId>,
+    ) -> Result<AllTransactionsResponse, String> {
+        self.get::<AllTransactionsResponse>(request).await
+    }
 }
+    
+
+
+
 
 /// Handles the response received from an HTTP request made to the Horizon server.
 ///

--- a/stellar_rust_sdk/src/ledgers/mod.rs
+++ b/stellar_rust_sdk/src/ledgers/mod.rs
@@ -43,7 +43,7 @@ pub mod single_ledger_request;
 /// This variable is intended to be used internally by the request-building logic
 /// to ensure consistent and accurate path construction for ledger-related API calls.
 ///
-static LEDGERS_PATH: &str = "ledgers";
+pub(crate) static LEDGERS_PATH: &str = "ledgers";
 
 /// The `prelude` module for the `ledgers` module in the Stellar Horizon Rust SDK.
 ///

--- a/stellar_rust_sdk/src/transactions/mod.rs
+++ b/stellar_rust_sdk/src/transactions/mod.rs
@@ -71,6 +71,7 @@ static TRANSACTIONS_PATH: &str = "transactions";
 pub mod prelude {
     pub use super::single_transaction_request::*;
     pub use super::all_transactions_request::*;
+    pub use super::transactions_for_account_request::*;
     pub use super::response::*;
 }
 
@@ -79,37 +80,38 @@ pub mod test {
     use super::prelude::*;
     use crate::horizon_client::HorizonClient;
 
+    const LINK_SELF: &str = "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
+    const LINK_ACCOUNT: &str = "https://horizon-testnet.stellar.org/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
+    const LINK_LEDGER: &str = "https://horizon-testnet.stellar.org/ledgers/539";
+    const LINK_OPERATIONS: &str = "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020/operations{?cursor,limit,order}";
+    const LINK_EFFECTS: &str = "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020/effects{?cursor,limit,order}";
+    const LINK_PRECEDES: &str = "https://horizon-testnet.stellar.org/transactions?order=asc&cursor=2314987376640";
+    const LINK_SUCCEEDS: &str = "https://horizon-testnet.stellar.org/transactions?order=desc&cursor=2314987376640";
+    const LINK_TRANSACTION: &str = "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
+    const ID: &str = "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
+    const PAGING_TOKEN: &str = "2314987376640";
+    const SUCCESSFUL: &bool = &true;
+    const HASH: &str = "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
+    const LEDGER: &i64 = &539;
+    const CREATED_AT: &str = "2024-06-11T21:36:12Z";
+    const SOURCE_ACCOUNT: &str = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
+    const SOURCE_ACCOUNT_SEQUENCE: &str = "1";
+    const FEE_ACCOUNT: &str = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
+    const FEE_CHARGED: &str = "1100";
+    const MAX_FEE: &str = "1100";
+    const OPERATION_COUNT: &i64 = &11;
+    // TODO: Is it necessary to test the following 4 values, as they're very long?
+    // const ENVELOPE_XDR: &str = "";
+    // const RESULT_XDR: &str = "";
+    // const RESULT_META_XDR: &str = "";
+    // const FEE_META_XDR: &str = "";
+    const MEMO_TYPE: &str = "none";
+    const SIGNATURE: &str = "NUHx9PZlcXQ9mq1lf1usrSTP4/gbxUqzUOQOSU/pQuy9dF7FcUF0fjEbzFECxHUcl4QEfbvyGIE029TA3DrODA==";
+    const VALID_AFTER: &str = "1970-01-01T00:00:00Z";
+    const MIN_TIME: &str = "0";
+
     #[tokio::test]
     async fn test_get_single_transaction() {
-        const LINK_SELF: &str = "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
-        const LINK_ACCOUNT: &str = "https://horizon-testnet.stellar.org/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
-        const LINK_LEDGER: &str = "https://horizon-testnet.stellar.org/ledgers/539";
-        const LINK_OPERATIONS: &str = "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020/operations{?cursor,limit,order}";
-        const LINK_EFFECTS: &str = "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020/effects{?cursor,limit,order}";
-        const LINK_PRECEDES: &str = "https://horizon-testnet.stellar.org/transactions?order=asc&cursor=2314987376640";
-        const LINK_SUCCEEDS: &str = "https://horizon-testnet.stellar.org/transactions?order=desc&cursor=2314987376640";
-        const LINK_TRANSACTION: &str = "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
-        const ID: &str = "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
-        const PAGING_TOKEN: &str = "2314987376640";
-        const SUCCESSFUL: &bool = &true;
-        const HASH: &str = "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
-        const LEDGER: &i64 = &539;
-        const CREATED_AT: &str = "2024-06-11T21:36:12Z";
-        const SOURCE_ACCOUNT: &str = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
-        const SOURCE_ACCOUNT_SEQUENCE: &str = "1";
-        const FEE_ACCOUNT: &str = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
-        const FEE_CHARGED: &str = "1100";
-        const MAX_FEE: &str = "1100";
-        const OPERATION_COUNT: &i64 = &11;
-        // TODO: Is it necessary to test the following 4 values, as they're very long?
-        // const ENVELOPE_XDR: &str = "";
-        // const RESULT_XDR: &str = "";
-        // const RESULT_META_XDR: &str = "";
-        // const FEE_META_XDR: &str = "";
-        const MEMO_TYPE: &str = "none";
-        const SIGNATURE: &str = "NUHx9PZlcXQ9mq1lf1usrSTP4/gbxUqzUOQOSU/pQuy9dF7FcUF0fjEbzFECxHUcl4QEfbvyGIE029TA3DrODA==";
-        const VALID_AFTER: &str = "1970-01-01T00:00:00Z";
-        const MIN_TIME: &str = "0";
 
         let horizon_client =
             HorizonClient::new("https://horizon-testnet.stellar.org"
@@ -155,31 +157,6 @@ pub mod test {
 
     #[tokio::test]
     async fn test_get_all_transactions() {
-        const LINK_SELF: &str = "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
-        const LINK_ACCOUNT: &str = "https://horizon-testnet.stellar.org/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
-        const LINK_LEDGER: &str = "https://horizon-testnet.stellar.org/ledgers/539";
-        const LINK_OPERATIONS: &str = "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020/operations{?cursor,limit,order}";
-        const LINK_EFFECTS: &str =  "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020/effects{?cursor,limit,order}";
-        const LINK_PRECEDES: &str = "https://horizon-testnet.stellar.org/transactions?order=asc&cursor=2314987376640";
-        const LINK_SUCCEEDS: &str = "https://horizon-testnet.stellar.org/transactions?order=desc&cursor=2314987376640";
-        const LINK_TRANSACTION: &str = "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
-        const ID: &str = "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
-        const PAGING_TOKEN: &str = "2314987376640";
-        const SUCCESSFUL: &bool = &true;
-        const HASH: &str = "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
-        const LEDGER: &i64 = &539;
-        const CREATED_AT: &str = "2024-06-11T21:36:12Z";
-        const SOURCE_ACCOUNT: &str = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
-        const SOURCE_ACCOUNT_SEQUENCE: &str = "1";
-        const FEE_ACCOUNT: &str = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
-        const FEE_CHARGED: &str = "1100";
-        const MAX_FEE: &str = "1100";
-        const OPERATION_COUNT: &i64 = &11;
-        const MEMO_TYPE: &str = "none";
-        const SIGNATURE: &str = "NUHx9PZlcXQ9mq1lf1usrSTP4/gbxUqzUOQOSU/pQuy9dF7FcUF0fjEbzFECxHUcl4QEfbvyGIE029TA3DrODA==";
-        const VALID_AFTER: &str = "1970-01-01T00:00:00Z";
-        const MIN_TIME: &str = "0";
-
         let horizon_client =
             HorizonClient::new("https://horizon-testnet.stellar.org"
             .to_string())
@@ -194,6 +171,51 @@ pub mod test {
 
         assert!(all_transactions_response.clone().is_ok());
         let binding = all_transactions_response.unwrap();
+        let record = &binding.embedded().records()[0];
+        assert_eq!(record.links().self_link().href().as_ref().unwrap(), LINK_SELF);
+        assert_eq!(record.links().account().href().as_ref().unwrap(), LINK_ACCOUNT);
+        assert_eq!(record.links().ledger().href().as_ref().unwrap(), LINK_LEDGER);
+        assert_eq!(record.links().operations().href().as_ref().unwrap(), LINK_OPERATIONS);
+        assert_eq!(record.links().effects().href().as_ref().unwrap(), LINK_EFFECTS);
+        assert_eq!(record.links().precedes().href().as_ref().unwrap(), LINK_PRECEDES);
+        assert_eq!(record.links().succeeds().href().as_ref().unwrap(), LINK_SUCCEEDS);
+        assert_eq!(record.links().transaction().href().as_ref().unwrap(), LINK_TRANSACTION);
+        assert_eq!(record.id(), ID);
+        assert_eq!(record.paging_token(), PAGING_TOKEN);
+        assert_eq!(record.successful(), SUCCESSFUL);
+        assert_eq!(record.hash(), HASH);
+        assert_eq!(record.ledger(), LEDGER);
+        assert_eq!(record.created_at(), CREATED_AT);
+        assert_eq!(record.source_account(), SOURCE_ACCOUNT);
+        assert_eq!(record.source_account_sequence(), SOURCE_ACCOUNT_SEQUENCE);
+        assert_eq!(record.fee_account(), FEE_ACCOUNT);
+        assert_eq!(record.fee_charged(), FEE_CHARGED);
+        assert_eq!(record.max_fee(), MAX_FEE);
+        assert_eq!(record.operation_count(), OPERATION_COUNT);
+        assert_eq!(record.memo_type(), MEMO_TYPE);
+        assert_eq!(record.signatures()[0], SIGNATURE); // Check only the first signature of the vector
+        assert_eq!(record.valid_after().as_ref().unwrap(), VALID_AFTER);
+        assert_eq!(record.preconditions().as_ref().unwrap().timebounds().min_time(), MIN_TIME);
+    }
+
+    #[tokio::test]
+    async fn test_get_transactions_for_account() {
+
+        let horizon_client =
+            HorizonClient::new("https://horizon-testnet.stellar.org"
+            .to_string())
+            .unwrap();
+
+        let transactions_for_account_request = TransactionsForAccountRequest::new()
+            .set_account_id("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H".to_string())
+            .unwrap();
+
+        let transactions_for_account_response = horizon_client
+            .get_transactions_for_account(&transactions_for_account_request)
+            .await;
+
+        assert!(transactions_for_account_response.clone().is_ok());
+        let binding = transactions_for_account_response.unwrap();
         let record = &binding.embedded().records()[0];
         assert_eq!(record.links().self_link().href().as_ref().unwrap(), LINK_SELF);
         assert_eq!(record.links().account().href().as_ref().unwrap(), LINK_ACCOUNT);

--- a/stellar_rust_sdk/src/transactions/mod.rs
+++ b/stellar_rust_sdk/src/transactions/mod.rs
@@ -21,6 +21,9 @@ pub mod all_transactions_request;
 // TODO: Documentation
 pub mod transactions_for_account_request;
 
+// TODO: Documentation
+pub mod transactions_for_ledger_request;
+
 /// Provides the responses.
 ///
 /// This module defines structures representing the response from the Horizon API when querying
@@ -72,6 +75,7 @@ pub mod prelude {
     pub use super::single_transaction_request::*;
     pub use super::all_transactions_request::*;
     pub use super::transactions_for_account_request::*;
+    pub use super::transactions_for_ledger_request::*;
     pub use super::response::*;
 }
 

--- a/stellar_rust_sdk/src/transactions/mod.rs
+++ b/stellar_rust_sdk/src/transactions/mod.rs
@@ -24,6 +24,10 @@ pub mod transactions_for_account_request;
 // TODO: Documentation
 pub mod transactions_for_ledger_request;
 
+// TODO: Documentation
+pub mod transactions_for_liquidity_pool_request;
+
+
 /// Provides the responses.
 ///
 /// This module defines structures representing the response from the Horizon API when querying
@@ -76,6 +80,7 @@ pub mod prelude {
     pub use super::all_transactions_request::*;
     pub use super::transactions_for_account_request::*;
     pub use super::transactions_for_ledger_request::*;
+    pub use super::transactions_for_liquidity_pool_request::*;
     pub use super::response::*;
 }
 

--- a/stellar_rust_sdk/src/transactions/mod.rs
+++ b/stellar_rust_sdk/src/transactions/mod.rs
@@ -246,4 +246,53 @@ pub mod test {
         assert_eq!(record.valid_after().as_ref().unwrap(), VALID_AFTER);
         assert_eq!(record.preconditions().as_ref().unwrap().timebounds().min_time(), MIN_TIME);
     }
+
+    #[tokio::test]
+    async fn test_get_transactions_for_ledger() {
+        use crate::{models::*, BuildQueryParametersExt, Paginatable};
+
+        const LEDGER_SEQUENCE: &str = "539";
+
+        let horizon_client =
+            HorizonClient::new("https://horizon-testnet.stellar.org"
+            .to_string())
+            .unwrap();
+
+        let transactions_for_ledger_request = TransactionsForLedgerRequest::new()
+            .set_ledger_sequence(LEDGER_SEQUENCE.to_string())
+            .unwrap()
+            .set_include_failed(true).unwrap();
+
+        let transactions_for_ledger_response = horizon_client
+            .get_transactions_for_ledger(&transactions_for_ledger_request)
+            .await;
+
+        assert!(transactions_for_ledger_response.clone().is_ok());
+        let binding = transactions_for_ledger_response.unwrap();
+        let record = &binding.embedded().records()[0];
+        assert_eq!(record.links().self_link().href().as_ref().unwrap(), LINK_SELF);
+        assert_eq!(record.links().account().href().as_ref().unwrap(), LINK_ACCOUNT);
+        assert_eq!(record.links().ledger().href().as_ref().unwrap(), LINK_LEDGER);
+        assert_eq!(record.links().operations().href().as_ref().unwrap(), LINK_OPERATIONS);
+        assert_eq!(record.links().effects().href().as_ref().unwrap(), LINK_EFFECTS);
+        assert_eq!(record.links().precedes().href().as_ref().unwrap(), LINK_PRECEDES);
+        assert_eq!(record.links().succeeds().href().as_ref().unwrap(), LINK_SUCCEEDS);
+        assert_eq!(record.links().transaction().href().as_ref().unwrap(), LINK_TRANSACTION);
+        assert_eq!(record.id(), ID);
+        assert_eq!(record.paging_token(), PAGING_TOKEN);
+        assert_eq!(record.successful(), SUCCESSFUL);
+        assert_eq!(record.hash(), HASH);
+        assert_eq!(record.ledger(), LEDGER);
+        assert_eq!(record.created_at(), CREATED_AT);
+        assert_eq!(record.source_account(), SOURCE_ACCOUNT);
+        assert_eq!(record.source_account_sequence(), SOURCE_ACCOUNT_SEQUENCE);
+        assert_eq!(record.fee_account(), FEE_ACCOUNT);
+        assert_eq!(record.fee_charged(), FEE_CHARGED);
+        assert_eq!(record.max_fee(), MAX_FEE);
+        assert_eq!(record.operation_count(), OPERATION_COUNT);
+        assert_eq!(record.memo_type(), MEMO_TYPE);
+        assert_eq!(record.signatures()[0], SIGNATURE); // Check only the first signature of the vector
+        assert_eq!(record.valid_after().as_ref().unwrap(), VALID_AFTER);
+        assert_eq!(record.preconditions().as_ref().unwrap().timebounds().min_time(), MIN_TIME);
+    }
 }

--- a/stellar_rust_sdk/src/transactions/mod.rs
+++ b/stellar_rust_sdk/src/transactions/mod.rs
@@ -18,6 +18,9 @@ pub mod single_transaction_request;
 ///
 pub mod all_transactions_request;
 
+// TODO: Documentation
+pub mod transactions_for_account_request;
+
 /// Provides the responses.
 ///
 /// This module defines structures representing the response from the Horizon API when querying

--- a/stellar_rust_sdk/src/transactions/mod.rs
+++ b/stellar_rust_sdk/src/transactions/mod.rs
@@ -18,13 +18,35 @@ pub mod single_transaction_request;
 ///
 pub mod all_transactions_request;
 
-// TODO: Documentation
+/// Provides the `TransactionsForAccountRequest`.
+///
+/// # Usage
+/// This module provides the `TransactionsForAccountRequest` struct, specifically designed for
+/// constructing requests to query information about all successful transactions for a given account from the Horizon
+/// server. It is tailored for use with the [`HorizonClient::get_transactions_for_account`](crate::horizon_client::HorizonClient::get_transactions_for_account)
+/// method.
+///
 pub mod transactions_for_account_request;
 
-// TODO: Documentation
+/// Provides the `TransactionsForLedgersRequest`.
+///
+/// # Usage
+/// This module provides the `TransactionsForLedgersRequest` struct, specifically designed for
+/// constructing requests to query information about all successful transactions in a given ledger from the Horizon
+/// server. It is tailored for use with the [`HorizonClient::get_transactions_for_ledger`](crate::horizon_client::HorizonClient::get_transactions_for_ledger)
+/// method.
+///
 pub mod transactions_for_ledger_request;
 
-// TODO: Documentation
+/// Provides the `TransactionsForLiquidityPoolRequest`.
+///
+/// # Usage
+/// This module provides the `TransactionsForLiquidityPoolRequest` struct, specifically designed for
+/// constructing requests to query information about all successful transactions referencing 
+/// a given liquidity pool from the Horizon server. 
+/// It is tailored for use with the [`HorizonClient::get_transactions_for_liquidity_pool`](crate::horizon_client::HorizonClient::get_transactions_for_liquidity_pool)
+/// method.
+///
 pub mod transactions_for_liquidity_pool_request;
 
 
@@ -121,7 +143,6 @@ pub mod test {
 
     #[tokio::test]
     async fn test_get_single_transaction() {
-
         let horizon_client =
             HorizonClient::new("https://horizon-testnet.stellar.org"
             .to_string())
@@ -172,7 +193,8 @@ pub mod test {
             .unwrap();
 
         let all_transactions_request = AllTransactionsRequest::new()
-            .set_include_failed(true).unwrap();
+            .set_include_failed(true)
+            .unwrap();
 
         let all_transactions_response = horizon_client
             .get_all_transactions(&all_transactions_request)
@@ -209,7 +231,6 @@ pub mod test {
 
     #[tokio::test]
     async fn test_get_transactions_for_account() {
-
         let horizon_client =
             HorizonClient::new("https://horizon-testnet.stellar.org"
             .to_string())
@@ -217,6 +238,8 @@ pub mod test {
 
         let transactions_for_account_request = TransactionsForAccountRequest::new()
             .set_account_id("GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H".to_string())
+            .unwrap()
+            .set_include_failed(true)
             .unwrap();
 
         let transactions_for_account_response = horizon_client
@@ -254,8 +277,6 @@ pub mod test {
 
     #[tokio::test]
     async fn test_get_transactions_for_ledger() {
-        use crate::{models::*, BuildQueryParametersExt, Paginatable};
-
         const LEDGER_SEQUENCE: &str = "539";
 
         let horizon_client =
@@ -266,7 +287,8 @@ pub mod test {
         let transactions_for_ledger_request = TransactionsForLedgerRequest::new()
             .set_ledger_sequence(LEDGER_SEQUENCE.to_string())
             .unwrap()
-            .set_include_failed(true).unwrap();
+            .set_include_failed(true)
+            .unwrap();
 
         let transactions_for_ledger_response = horizon_client
             .get_transactions_for_ledger(&transactions_for_ledger_request)

--- a/stellar_rust_sdk/src/transactions/mod.rs
+++ b/stellar_rust_sdk/src/transactions/mod.rs
@@ -300,4 +300,76 @@ pub mod test {
         assert_eq!(record.valid_after().as_ref().unwrap(), VALID_AFTER);
         assert_eq!(record.preconditions().as_ref().unwrap().timebounds().min_time(), MIN_TIME);
     }
+
+    #[tokio::test]
+    async fn test_get_transactions_for_liquidity_pool() {
+        const LINK_SELF: &str = "https://horizon-testnet.stellar.org/transactions/1f6abb2a00ba84469f8d95271bf2eec99da10bddb894be11f29f7a7039f0c0a6";
+        const LINK_ACCOUNT: &str = "https://horizon-testnet.stellar.org/accounts/GDB4ZUD465ZQ2FQZ4GNHEWVYJKZVOGSMJOEUGMFVLOOARFS4YKMRBCRV";
+        const LINK_LEDGER: &str = "https://horizon-testnet.stellar.org/ledgers/106867";
+        const LINK_OPERATIONS: &str = "https://horizon-testnet.stellar.org/transactions/1f6abb2a00ba84469f8d95271bf2eec99da10bddb894be11f29f7a7039f0c0a6/operations{?cursor,limit,order}";
+        const LINK_EFFECTS: &str = "https://horizon-testnet.stellar.org/transactions/1f6abb2a00ba84469f8d95271bf2eec99da10bddb894be11f29f7a7039f0c0a6/effects{?cursor,limit,order}";
+        const LINK_PRECEDES: &str = "https://horizon-testnet.stellar.org/transactions?order=asc&cursor=458990270087168";
+        const LINK_SUCCEEDS: &str = "https://horizon-testnet.stellar.org/transactions?order=desc&cursor=458990270087168";
+        const LINK_TRANSACTION: &str = "https://horizon-testnet.stellar.org/transactions/1f6abb2a00ba84469f8d95271bf2eec99da10bddb894be11f29f7a7039f0c0a6";
+        const ID: &str = "1f6abb2a00ba84469f8d95271bf2eec99da10bddb894be11f29f7a7039f0c0a6";
+        const PAGING_TOKEN: &str = "458990270087168";
+        const SUCCESSFUL: &bool = &true;
+        const HASH: &str = "1f6abb2a00ba84469f8d95271bf2eec99da10bddb894be11f29f7a7039f0c0a6";
+        const LEDGER: &i64 = &106867;
+        const CREATED_AT: &str = "2024-06-18T08:54:13Z";
+        const SOURCE_ACCOUNT: &str = "GDB4ZUD465ZQ2FQZ4GNHEWVYJKZVOGSMJOEUGMFVLOOARFS4YKMRBCRV";
+        const SOURCE_ACCOUNT_SEQUENCE: &str = "458960205250561";
+        const FEE_ACCOUNT: &str = "GDB4ZUD465ZQ2FQZ4GNHEWVYJKZVOGSMJOEUGMFVLOOARFS4YKMRBCRV";
+        const FEE_CHARGED: &str = "100";
+        const MAX_FEE: &str = "100";
+        const OPERATION_COUNT: &i64 = &1;
+        const MEMO_TYPE: &str = "none";
+        const SIGNATURE: &str = "T8ediCtghc8L41mZpHLfWGe0a6pe+wfr1cdaHLApD6Kv0nKrQ6FK/biBWf50IrsMQjMfK61m3a997qQc3M3oDA==";
+        const VALID_AFTER: &str = "1970-01-01T00:00:00Z";
+        const MIN_TIME: &str = "0";
+    
+        const LIQUIDITY_POOL_ID: &str = "0066b15f5d0dc0be771209c33f3e4126383e58183a598eae8b3813024c6a6d10";
+
+        let horizon_client =
+            HorizonClient::new("https://horizon-testnet.stellar.org"
+            .to_string())
+            .unwrap();
+
+        let transactions_for_liquidity_pool_request = TransactionsForLiquidityPoolRequest::new()
+            .set_liquidity_pool_id(LIQUIDITY_POOL_ID.to_string())
+            .unwrap()
+            .set_include_failed(true).unwrap();
+
+        let transactions_for_liquidity_pool_response = horizon_client
+            .get_transactions_for_liquidity_pool(&transactions_for_liquidity_pool_request)
+            .await;
+
+        assert!(transactions_for_liquidity_pool_response.clone().is_ok());
+        let binding = transactions_for_liquidity_pool_response.unwrap();
+        let record = &binding.embedded().records()[0];
+        assert_eq!(record.links().self_link().href().as_ref().unwrap(), LINK_SELF);
+        assert_eq!(record.links().account().href().as_ref().unwrap(), LINK_ACCOUNT);
+        assert_eq!(record.links().ledger().href().as_ref().unwrap(), LINK_LEDGER);
+        assert_eq!(record.links().operations().href().as_ref().unwrap(), LINK_OPERATIONS);
+        assert_eq!(record.links().effects().href().as_ref().unwrap(), LINK_EFFECTS);
+        assert_eq!(record.links().precedes().href().as_ref().unwrap(), LINK_PRECEDES);
+        assert_eq!(record.links().succeeds().href().as_ref().unwrap(), LINK_SUCCEEDS);
+        assert_eq!(record.links().transaction().href().as_ref().unwrap(), LINK_TRANSACTION);
+        assert_eq!(record.id(), ID);
+        assert_eq!(record.paging_token(), PAGING_TOKEN);
+        assert_eq!(record.successful(), SUCCESSFUL);
+        assert_eq!(record.hash(), HASH);
+        assert_eq!(record.ledger(), LEDGER);
+        assert_eq!(record.created_at(), CREATED_AT);
+        assert_eq!(record.source_account(), SOURCE_ACCOUNT);
+        assert_eq!(record.source_account_sequence(), SOURCE_ACCOUNT_SEQUENCE);
+        assert_eq!(record.fee_account(), FEE_ACCOUNT);
+        assert_eq!(record.fee_charged(), FEE_CHARGED);
+        assert_eq!(record.max_fee(), MAX_FEE);
+        assert_eq!(record.operation_count(), OPERATION_COUNT);
+        assert_eq!(record.memo_type(), MEMO_TYPE);
+        assert_eq!(record.signatures()[0], SIGNATURE); // Check only the first signature of the vector
+        assert_eq!(record.valid_after().as_ref().unwrap(), VALID_AFTER);
+        assert_eq!(record.preconditions().as_ref().unwrap().timebounds().min_time(), MIN_TIME);
+    }
 }

--- a/stellar_rust_sdk/src/transactions/transactions_for_account_request.rs
+++ b/stellar_rust_sdk/src/transactions/transactions_for_account_request.rs
@@ -2,11 +2,11 @@ use crate::{models::*, BuildQueryParametersExt};
 use stellar_rust_sdk_derive::Pagination;
 use crate::Paginatable;
 
-// TODO: Documentation
+/// Represents the ID of an account for which the transactions are to be retrieved.
 #[derive(Default, Clone)]
 pub struct TransactionsAccountId(String);
 
-// TODO: Documentation
+/// Represents the absence of an ID of an account for which the transactions are to be retrieved.
 #[derive(Default, Clone)]
 pub struct NoTransactionsAccountId;
 
@@ -56,6 +56,15 @@ impl TransactionsForAccountRequest<NoTransactionsAccountId> {
 }
 
 impl TransactionsForAccountRequest<TransactionsAccountId> {
+    /// Sets the `include_failed` field for the request. Can only be set on a request that
+    /// has a set account id.
+    ///
+    /// # Arguments
+    /// * `include_failed` - A `bool` to indicate whether or not to include failed operations.
+    ///
+    /// # Returns
+    /// A `TransactionsForAccountRequest` with the updated `include_failed` field.
+    ///
     pub fn set_include_failed(
         self,
         include_failed: bool,
@@ -84,7 +93,8 @@ impl Request for TransactionsForAccountRequest<TransactionsAccountId> {
     }
 
     fn build_url(&self, base_url: &str) -> String {
-        // TODO: Documentation
+        // This URL comprises paths and query parameters.
+        // Additionally, this request uses the API endpoint for `accounts`.
         let account_id = &self.account_id.0;
         use crate::accounts::ACCOUNTS_PATH;
         format!(

--- a/stellar_rust_sdk/src/transactions/transactions_for_account_request.rs
+++ b/stellar_rust_sdk/src/transactions/transactions_for_account_request.rs
@@ -1,0 +1,80 @@
+use crate::models::*;
+use stellar_rust_sdk_derive::Pagination;
+use crate::Paginatable;
+
+// TODO: Documentation
+#[derive(Default, Clone)]
+pub struct TransactionsAccountId(String);
+
+// TODO: Documentation
+#[derive(Default, Clone)]
+pub struct NoTransactionsAccountId;
+
+#[derive(Default, Pagination)]
+pub struct TransactionsForAccountRequest<I> {
+    /// The ID of the account for which the transactions are to be retrieved.
+    account_id: I,
+    /// A pointer to a specific location in a collection of responses, derived from the
+    /// `paging_token` value of a record. Used for pagination control in the API response.
+    pub cursor: Option<u32>,
+    /// Specifies the maximum number of records to be returned in a single response.
+    /// The range for this parameter is from 1 to 200. The default value is set to 10.
+    pub limit: Option<u8>,
+    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
+    /// and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
+    pub order: Option<Order>,
+}
+
+impl TransactionsForAccountRequest<NoTransactionsAccountId> {
+    /// Creates a new `TransactionsForAccountRequest` with default parameters.
+    pub fn new() -> Self {
+        TransactionsForAccountRequest::default()
+    }
+
+    /// Sets the account ID for the request.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID for which the transactions are to be retrieved.
+    ///
+    /// # Returns
+    /// A `TransactionsForAccountRequest` with the specified account ID, or an error if the account ID is invalid.
+    ///
+    pub fn set_account_id(
+        self,
+        account_id: String,
+    ) -> Result<TransactionsForAccountRequest<TransactionsAccountId>, String> {
+        if let Err(e) = is_public_key(&account_id) {
+            return Err(e.to_string());
+        }
+
+        Ok(TransactionsForAccountRequest {
+            account_id: TransactionsAccountId(account_id),
+            cursor: self.cursor,
+            limit: self.limit,
+            order: self.order,
+        })
+    }
+}
+
+impl Request for TransactionsForAccountRequest<TransactionsAccountId> {
+    fn get_query_parameters(&self) -> String {
+        let mut query = String::new();
+        query.push_str(&format!("{}", self.account_id.0));
+
+        query.trim_end_matches('&').to_string()
+    }
+
+    fn build_url(&self, base_url: &str) -> String {
+        // This URL is not built with query paramaters, but with the account ID as addition to the path.
+        // Therefore there is no `?` but a `/` in the formatted string.
+        // Additionally, this request uses the API endpoint for `accounts`.
+        use crate::accounts::ACCOUNTS_PATH;
+        format!(
+            "{}/{}/{}/{}",
+            base_url,
+            ACCOUNTS_PATH,
+            self.get_query_parameters(),
+            super::TRANSACTIONS_PATH
+        )
+    }
+}

--- a/stellar_rust_sdk/src/transactions/transactions_for_ledger_request.rs
+++ b/stellar_rust_sdk/src/transactions/transactions_for_ledger_request.rs
@@ -1,0 +1,99 @@
+use crate::{models::*, BuildQueryParametersExt};
+use stellar_rust_sdk_derive::Pagination;
+use crate::Paginatable;
+
+// TODO: Documentation
+#[derive(Default, Clone)]
+pub struct TransactionsLedgerId(String);
+
+// TODO: Documentation
+#[derive(Default, Clone)]
+pub struct NoTransactionsLedgerId;
+
+#[derive(Default, Pagination)]
+pub struct TransactionsForLedgerRequest<S> {
+    /// The ID of the account for which the transactions are to be retrieved.
+    ledger_sequence: S,
+    // Indicates whether or not to include failed operations in the response.
+    include_failed: Option<bool>,
+    /// A pointer to a specific location in a collection of responses, derived from the
+    /// `paging_token` value of a record. Used for pagination control in the API response.
+    pub cursor: Option<u32>,
+    /// Specifies the maximum number of records to be returned in a single response.
+    /// The range for this parameter is from 1 to 200. The default value is set to 10.
+    pub limit: Option<u8>,
+    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
+    /// and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
+    pub order: Option<Order>,
+}
+
+impl TransactionsForLedgerRequest<NoTransactionsLedgerId> {
+    /// Creates a new `TransactionsForLedgerRequest` with default parameters.
+    pub fn new() -> Self {
+        TransactionsForLedgerRequest::default()
+    }
+
+    /// Sets the account ID for the request.
+    ///
+    /// # Arguments
+    /// * `account_id` - The account ID for which the transactions are to be retrieved.
+    ///
+    /// # Returns
+    /// A `TransactionsForAccountRequest` with the specified account ID, or an error if the account ID is invalid.
+    ///
+    pub fn set_ledger_sequence(
+        self,
+        ledger_sequence: String,
+    ) -> Result<TransactionsForLedgerRequest<TransactionsLedgerId>, String> {
+        Ok(TransactionsForLedgerRequest {
+            ledger_sequence: TransactionsLedgerId(ledger_sequence),
+            include_failed: self.include_failed,
+            cursor: self.cursor,
+            limit: self.limit,
+            order: self.order,
+        })
+    }
+}
+
+impl TransactionsForLedgerRequest<TransactionsLedgerId> {
+    pub fn set_include_failed(
+        self,
+        include_failed: bool,
+    ) -> Result<TransactionsForLedgerRequest<TransactionsLedgerId>, String> {
+        Ok(TransactionsForLedgerRequest {
+            ledger_sequence: self.ledger_sequence,
+            include_failed: Some(include_failed),
+            cursor: self.cursor,
+            limit: self.limit,
+            order: self.order,
+        })
+    }
+}
+
+impl Request for TransactionsForLedgerRequest<TransactionsLedgerId> {
+    fn get_query_parameters(&self) -> String {
+        vec![
+            self.cursor.as_ref().map(|c| format!("cursor={}", c)),
+            self.limit.as_ref().map(|l| format!("limit={}", l)),
+            self.order.as_ref().map(|o| format!("order={}", o)),
+            self.include_failed
+                .as_ref()
+                .map(|i| format!("include_failed={}", i)),
+        ]
+        .build_query_parameters()
+    }
+
+    fn build_url(&self, base_url: &str) -> String {
+        // TODO: Documentation
+        let ledger_sequence = &self.ledger_sequence.0;
+        use crate::ledgers::LEDGERS_PATH;
+        format!(
+            "{}/{}/{}/{}{}",
+            base_url,
+            LEDGERS_PATH,
+            ledger_sequence,
+            super::TRANSACTIONS_PATH,
+            self.get_query_parameters(),
+        )
+    }
+}

--- a/stellar_rust_sdk/src/transactions/transactions_for_ledger_request.rs
+++ b/stellar_rust_sdk/src/transactions/transactions_for_ledger_request.rs
@@ -2,17 +2,17 @@ use crate::{models::*, BuildQueryParametersExt};
 use stellar_rust_sdk_derive::Pagination;
 use crate::Paginatable;
 
-// TODO: Documentation
+/// Represents the ID of a ledger for which the transactions are to be retrieved.
 #[derive(Default, Clone)]
 pub struct TransactionsLedgerId(String);
 
-// TODO: Documentation
+/// Represents the absence of an ID of a ledger for which the transactions are to be retrieved.
 #[derive(Default, Clone)]
 pub struct NoTransactionsLedgerId;
 
 #[derive(Default, Pagination)]
 pub struct TransactionsForLedgerRequest<S> {
-    /// The ID of the account for which the transactions are to be retrieved.
+    /// The ID of the ledger for which the transactions are to be retrieved.
     ledger_sequence: S,
     // Indicates whether or not to include failed operations in the response.
     include_failed: Option<bool>,
@@ -33,13 +33,13 @@ impl TransactionsForLedgerRequest<NoTransactionsLedgerId> {
         TransactionsForLedgerRequest::default()
     }
 
-    /// Sets the account ID for the request.
+    /// Sets the ledger ID for the request.
     ///
     /// # Arguments
-    /// * `account_id` - The account ID for which the transactions are to be retrieved.
+    /// * `ledger_id` - The ledger ID for which the transactions are to be retrieved.
     ///
     /// # Returns
-    /// A `TransactionsForAccountRequest` with the specified account ID, or an error if the account ID is invalid.
+    /// A `TransactionsForLedgerRequest` with the specified ledger ID.
     ///
     pub fn set_ledger_sequence(
         self,
@@ -56,6 +56,15 @@ impl TransactionsForLedgerRequest<NoTransactionsLedgerId> {
 }
 
 impl TransactionsForLedgerRequest<TransactionsLedgerId> {
+    /// Sets the `include_failed` field for the request. Can only be set on a request that
+    /// has a set ledger id.
+    ///
+    /// # Arguments
+    /// * `include_failed` - A `bool` to indicate whether or not to include failed operations.
+    ///
+    /// # Returns
+    /// A `TransactionsForLedgerRequest` with the updated `include_failed` field.
+    ///
     pub fn set_include_failed(
         self,
         include_failed: bool,
@@ -84,7 +93,8 @@ impl Request for TransactionsForLedgerRequest<TransactionsLedgerId> {
     }
 
     fn build_url(&self, base_url: &str) -> String {
-        // TODO: Documentation
+        // This URL comprises paths and query parameters.
+        // Additionally, this request uses the API endpoint for `ledgers`.
         let ledger_sequence = &self.ledger_sequence.0;
         use crate::ledgers::LEDGERS_PATH;
         format!(

--- a/stellar_rust_sdk/src/transactions/transactions_for_liquidity_pool_request.rs
+++ b/stellar_rust_sdk/src/transactions/transactions_for_liquidity_pool_request.rs
@@ -1,0 +1,103 @@
+use crate::{models::*, BuildQueryParametersExt};
+use stellar_rust_sdk_derive::Pagination;
+use crate::Paginatable;
+
+// TODO: Documentation
+#[derive(Default, Clone)]
+pub struct TransactionsLiquidityPoolId(String);
+
+// TODO: Documentation
+#[derive(Default, Clone)]
+pub struct NoTransactionsLiquidityPoolId;
+
+#[derive(Default, Pagination)]
+pub struct TransactionsForLiquidityPoolRequest<I> {
+    /// The ID of the liquidity pool for which the transactions are to be retrieved.
+    liquidity_pool_id: I,
+    // Indicates whether or not to include failed operations in the response.
+    include_failed: Option<bool>,
+    /// A pointer to a specific location in a collection of responses, derived from the
+    /// `paging_token` value of a record. Used for pagination control in the API response.
+    pub cursor: Option<u32>,
+    /// Specifies the maximum number of records to be returned in a single response.
+    /// The range for this parameter is from 1 to 200. The default value is set to 10.
+    pub limit: Option<u8>,
+    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
+    /// and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
+    pub order: Option<Order>,
+}
+
+impl TransactionsForLiquidityPoolRequest<NoTransactionsLiquidityPoolId> {
+    /// Creates a new `TransactionsForLiquidityPoolRequest` with default parameters.
+    pub fn new() -> Self {
+        TransactionsForLiquidityPoolRequest::default()
+    }
+
+    /// Sets the liquidity pool ID for the request.
+    ///
+    /// # Arguments
+    /// * `liquidity_pool_id` - The liquidity pool ID for which the transactions are to be retrieved.
+    ///
+    /// # Returns
+    /// A `TransactionsForLiquidityPoolRequest` with the specified liquidity pool ID, or an error if the liquidity pool ID is invalid.
+    ///
+    pub fn set_liquidity_pool_id(
+        self,
+        liquidity_pool_id: String,
+    ) -> Result<TransactionsForLiquidityPoolRequest<TransactionsLiquidityPoolId>, String> {
+        if let Err(e) = is_public_key(&liquidity_pool_id) {
+            return Err(e.to_string());
+        }
+
+        Ok(TransactionsForLiquidityPoolRequest {
+            liquidity_pool_id: TransactionsLiquidityPoolId(liquidity_pool_id),
+            include_failed: self.include_failed,
+            cursor: self.cursor,
+            limit: self.limit,
+            order: self.order,
+        })
+    }
+}
+
+impl TransactionsForLiquidityPoolRequest<TransactionsLiquidityPoolId> {
+    pub fn set_include_failed(
+        self,
+        include_failed: bool,
+    ) -> Result<TransactionsForLiquidityPoolRequest<TransactionsLiquidityPoolId>, String> {
+        Ok(TransactionsForLiquidityPoolRequest {
+            liquidity_pool_id: self.liquidity_pool_id,
+            include_failed: Some(include_failed),
+            cursor: self.cursor,
+            limit: self.limit,
+            order: self.order,
+        })
+    }
+}
+
+impl Request for TransactionsForLiquidityPoolRequest<TransactionsLiquidityPoolId> {
+    fn get_query_parameters(&self) -> String {
+        vec![
+            self.cursor.as_ref().map(|c| format!("cursor={}", c)),
+            self.limit.as_ref().map(|l| format!("limit={}", l)),
+            self.order.as_ref().map(|o| format!("order={}", o)),
+            self.include_failed
+                .as_ref()
+                .map(|i| format!("include_failed={}", i)),
+        ]
+        .build_query_parameters()
+    }
+
+    fn build_url(&self, base_url: &str) -> String {
+        // TODO: Documentation
+        let liquidity_pool_id = &self.liquidity_pool_id.0;
+        use crate::liquidity_pools::LIQUIDITY_POOLS_PATH;
+        format!(
+            "{}/{}/{}/{}{}",
+            base_url,
+            LIQUIDITY_POOLS_PATH,
+            liquidity_pool_id,
+            super::TRANSACTIONS_PATH,
+            self.get_query_parameters(),
+        )
+    }
+}

--- a/stellar_rust_sdk/src/transactions/transactions_for_liquidity_pool_request.rs
+++ b/stellar_rust_sdk/src/transactions/transactions_for_liquidity_pool_request.rs
@@ -45,10 +45,6 @@ impl TransactionsForLiquidityPoolRequest<NoTransactionsLiquidityPoolId> {
         self,
         liquidity_pool_id: String,
     ) -> Result<TransactionsForLiquidityPoolRequest<TransactionsLiquidityPoolId>, String> {
-        if let Err(e) = is_public_key(&liquidity_pool_id) {
-            return Err(e.to_string());
-        }
-
         Ok(TransactionsForLiquidityPoolRequest {
             liquidity_pool_id: TransactionsLiquidityPoolId(liquidity_pool_id),
             include_failed: self.include_failed,

--- a/stellar_rust_sdk/src/transactions/transactions_for_liquidity_pool_request.rs
+++ b/stellar_rust_sdk/src/transactions/transactions_for_liquidity_pool_request.rs
@@ -2,11 +2,11 @@ use crate::{models::*, BuildQueryParametersExt};
 use stellar_rust_sdk_derive::Pagination;
 use crate::Paginatable;
 
-// TODO: Documentation
+/// Represents the ID of a liquidity pool for which the transactions are to be retrieved.
 #[derive(Default, Clone)]
 pub struct TransactionsLiquidityPoolId(String);
 
-// TODO: Documentation
+/// Represents the absence of an ID of a liquidity pool for which the transactions are to be retrieved.
 #[derive(Default, Clone)]
 pub struct NoTransactionsLiquidityPoolId;
 
@@ -56,6 +56,15 @@ impl TransactionsForLiquidityPoolRequest<NoTransactionsLiquidityPoolId> {
 }
 
 impl TransactionsForLiquidityPoolRequest<TransactionsLiquidityPoolId> {
+    /// Sets the `include_failed` field for the request. Can only be set on a request that
+    /// has a set liquidity pool id.
+    ///
+    /// # Arguments
+    /// * `include_failed` - A `bool` to indicate whether or not to include failed operations.
+    ///
+    /// # Returns
+    /// A `TransactionsForLiquidityPoolRequest` with the updated `include_failed` field.
+    ///
     pub fn set_include_failed(
         self,
         include_failed: bool,
@@ -84,7 +93,8 @@ impl Request for TransactionsForLiquidityPoolRequest<TransactionsLiquidityPoolId
     }
 
     fn build_url(&self, base_url: &str) -> String {
-        // TODO: Documentation
+        // This URL comprises paths and query parameters.
+        // Additionally, this request uses the API endpoint for `liquidity_pools`.
         let liquidity_pool_id = &self.liquidity_pool_id.0;
         use crate::liquidity_pools::LIQUIDITY_POOLS_PATH;
         format!(


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Adds the following endpoints:
- transactions for accounts;
- transactions for ledgers;
- transactions for liquidity pools.

These conclude all 'get' endpoints, and leaves one final 'post' endpoint to be implemented.

### :boom: Does this PR introduce a breaking change?
No.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current main
