### PR TITLE
'Post Transaction' endpoint

### DIFF
--- a/stellar_rust_sdk/src/horizon_client.rs
+++ b/stellar_rust_sdk/src/horizon_client.rs
@@ -120,12 +120,50 @@ impl HorizonClient {
         Ok(result)
     }
 
-    // TODO: Documentation
+    /// Sends a POST request to the Horizon server and retrieves a specified response type.
+    ///
+    /// This internal asynchronous method is designed to handle various POST requests to the
+    /// Horizon server. It is generic over the response type, allowing for flexibility in
+    /// handling different types of responses as dictated by the caller. This method performs
+    /// key tasks such as request validation, URL construction, sending the request, and
+    /// processing the received response.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `Response` - Defines the expected response type. This type must implement the
+    /// [`Response`] trait.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - A reference to an object implementing the [`PostRequest`] trait. It contains
+    /// specific details about the POST request to be sent.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the response of type [`Response`] if the request is
+    /// successful. In case of failure (e.g., network issues, server errors), it returns an
+    /// error encapsulated as a `String`.
+    ///
+    /// # Example Usage
+    ///
+    /// This function is typically not called directly but through other specific methods of
+    /// the `HorizonClient` that define the type of request and response.
+    ///
+    /// # Remarks
+    ///
+    /// As a core utility function within `HorizonClient`, it centralizes the logic of sending
+    /// POST requests and handling responses. Modifications or enhancements to the request or
+    /// response handling logic should be implemented here to maintain consistency across the
+    /// client's interface.
+    ///
     async fn post<R: Response>(&self, request: &impl PostRequest) -> Result<R, String> {
-        // Construct the URL with potential query parameters.
+        // Construct the URL.
         let url = request.build_url(&self.base_url);
 
         // Send the request and await the response.
+        // The vector of tuples (containing the key/value pairs) returned by the `get_body()` method can
+        // be passed directly to `reqwest`s `form()` method, which will automatically create a valid
+        // formdata body for the request.
         let response = reqwest::Client::new()
             .post(&url)
             .form(&request.get_body())

--- a/stellar_rust_sdk/src/horizon_client.rs
+++ b/stellar_rust_sdk/src/horizon_client.rs
@@ -18,7 +18,7 @@ use crate::{
             AllLiquidityPoolsResponse, LiquidityPool, LiquidityPoolId, SingleLiquidityPoolRequest,
         },
     },
-    models::{Request, PostRequest, Response},
+    models::{PostRequest, Request, Response},
     offers::prelude::*,
     operations::{
         operations_for_account_request::OperationsForAccountRequest,
@@ -168,14 +168,15 @@ impl HorizonClient {
             .post(&url)
             .form(&request.get_body())
             .send()
-            .await.map_err(|e| e.to_string())?;
+            .await
+            .map_err(|e| e.to_string())?;
 
         // Process the response and return the result.
         let result: R = handle_response(response).await?;
-        
+
         Ok(result)
     }
- 
+
     /// Retrieves a list of accounts filtered by specific criteria.
     ///
     /// This method retrieves a list of accounts from the Horizon server, filtering the results
@@ -1628,7 +1629,6 @@ impl HorizonClient {
         self.get::<AllTradesResponse>(request).await
     }
 
-
     /// Fetches all liquidity pools from the Stellar Horizon API.
     ///
     /// This asynchronous method retrieves a list of all liquidity pools from the Horizon server.
@@ -2218,7 +2218,7 @@ impl HorizonClient {
     /// #    .expect("Failed to create Horizon Client");
     /// let signed_transaction_xdr = "AAAAAgAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9wAABEwAAAAAAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsAAAAAAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFjRXhdigAAAAAAAAAAAAAAAAAA3b5KF6uk1w1fSKYLrzR8gF2lB+AHAi6oU6CaWhunAskAAAAXSHboAAAAAAAAAAAAAAAAAHfmNeMLin2aTUfxa530ZRn4zwRu7ROAQfUJeJco8HSCAAHGv1JjQAAAAAAAAAAAAAAAAAAAlRt2go9sp7E1a5ZWvr7vin4UPrFQThpQax1lOFm33AAAABdIdugAAAAAAAAAAAAAAAAAmv+knlR6JR2VqWeU0k/4FgvZ/tSV5DEY4gu0iOTKgpUAAAAXSHboAAAAAAAAAAAAAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAF0h26AAAAAABAAAAAACVG3aCj2ynsTVrlla+vu+KfhQ+sVBOGlBrHWU4WbfcAAAABgAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bf/////////8AAAABAAAAAJr/pJ5UeiUdlalnlNJP+BYL2f7UleQxGOILtIjkyoKVAAAABgAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bf/////////8AAAABAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAAQAAAAAAlRt2go9sp7E1a5ZWvr7vin4UPrFQThpQax1lOFm33AAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAJGE5yoAAAAAABAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAAQAAAACa/6SeVHolHZWpZ5TST/gWC9n+1JXkMRjiC7SI5MqClQAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAJGE5yoAAAAAAAAAAAAAAAAABKBB+2UBMP/abwcm/M1TXO+/JQWhPwkalgqizKmXyRIQx7qh6aAFYAAAAAAAAAAARW/AX3AAAAQDVB8fT2ZXF0PZqtZX9brK0kz+P4G8VKs1DkDklP6ULsvXRexXFBdH4xG8xRAsR1HJeEBH278hiBNNvUwNw6zgzGYc0bAAAAQLgZUU/oYGL7frWDQhJHhCQu9JmfqN03PrJq4/cJrN1OSUWXnmLc94sv8m2L+cxl2p0skr2Jxy+vt1Lcxkv7wAI4WbfcAAAAQHvZEVqlygIProf3jVTZohDWm2WUNrFAFXf1LctTqDCQBHph14Eo+APwrTURLLYTIvNoXeGzBKbL03SsOARWcQLkyoKVAAAAQHAvKv2/Ro4+cNh6bKQO/G9NNiUozYysGwG1GvJQkFjwy/OTsL6WBfuI0Oye84lVBVrQVk2EY1ERFhgdMpuFSg4=";
     /// let request = PostTransactionRequest::new()
-    ///    .set_transaction_envelope_xdr(signed_transaction_xdr.to_string()).unwrap();
+    ///    .set_transaction_envelope_xdr(signed_transaction_xdr).unwrap();
     /// let response = horizon_client.post_transaction(&request).await;
     /// # Ok({})
     /// # }

--- a/stellar_rust_sdk/src/horizon_client.rs
+++ b/stellar_rust_sdk/src/horizon_client.rs
@@ -18,7 +18,7 @@ use crate::{
             AllLiquidityPoolsResponse, LiquidityPool, LiquidityPoolId, SingleLiquidityPoolRequest,
         },
     },
-    models::{Request, Response},
+    models::{Request, PostRequest, Response},
     offers::prelude::*,
     operations::{
         operations_for_account_request::OperationsForAccountRequest,
@@ -71,6 +71,73 @@ impl HorizonClient {
         Ok(Self { base_url })
     }
 
+    /// Sends a GET request to the Horizon server and retrieves a specified response type.
+    ///
+    /// This internal asynchronous method is designed to handle various GET requests to the
+    /// Horizon server. It is generic over the response type, allowing for flexibility in
+    /// handling different types of responses as dictated by the caller. This method performs
+    /// key tasks such as request validation, URL construction, sending the request, and
+    /// processing the received response.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `Response` - Defines the expected response type. This type must implement the
+    /// [`Response`] trait.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - A reference to an object implementing the [`Request`] trait. It contains
+    /// specific details about the GET request to be sent.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the response of type [`Response`] if the request is
+    /// successful. In case of failure (e.g., network issues, server errors), it returns an
+    /// error encapsulated as a `String`.
+    ///
+    /// # Example Usage
+    ///
+    /// This function is typically not called directly but through other specific methods of
+    /// the `HorizonClient` that define the type of request and response.
+    ///
+    /// # Remarks
+    ///
+    /// As a core utility function within `HorizonClient`, it centralizes the logic of sending
+    /// GET requests and handling responses. Modifications or enhancements to the request or
+    /// response handling logic should be implemented here to maintain consistency across the
+    /// client's interface.
+    ///
+    async fn get<R: Response>(&self, request: &impl Request) -> Result<R, String> {
+        // Construct the URL with potential query parameters.
+        let url = request.build_url(&self.base_url);
+
+        // Send the request and await the response.
+        let response = reqwest::get(&url).await.map_err(|e| e.to_string())?;
+
+        // Process the response and return the result.
+        let result: R = handle_response(response).await?;
+
+        Ok(result)
+    }
+
+    // TODO: Documentation
+    async fn post<R: Response>(&self, request: &impl PostRequest) -> Result<R, String> {
+        // Construct the URL with potential query parameters.
+        let url = request.build_url(&self.base_url);
+
+        // Send the request and await the response.
+        let response = reqwest::Client::new()
+            .post(&url)
+            .form(&request.get_body())
+            .send()
+            .await.map_err(|e| e.to_string())?;
+
+        // Process the response and return the result.
+        let result: R = handle_response(response).await?;
+        
+        Ok(result)
+    }
+ 
     /// Retrieves a list of accounts filtered by specific criteria.
     ///
     /// This method retrieves a list of accounts from the Horizon server, filtering the results
@@ -1523,53 +1590,6 @@ impl HorizonClient {
         self.get::<AllTradesResponse>(request).await
     }
 
-    /// Sends a GET request to the Horizon server and retrieves a specified response type.
-    ///
-    /// This internal asynchronous method is designed to handle various GET requests to the
-    /// Horizon server. It is generic over the response type, allowing for flexibility in
-    /// handling different types of responses as dictated by the caller. This method performs
-    /// key tasks such as request validation, URL construction, sending the request, and
-    /// processing the received response.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `Response` - Defines the expected response type. This type must implement the
-    /// [`Response`] trait.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - A reference to an object implementing the [`Request`] trait. It contains
-    /// specific details about the GET request to be sent.
-    ///
-    /// # Returns
-    ///
-    /// Returns a `Result` containing the response of type [`Response`] if the request is
-    /// successful. In case of failure (e.g., network issues, server errors), it returns an
-    /// error encapsulated as a `String`.
-    ///
-    /// # Example Usage
-    ///
-    /// This function is typically not called directly but through other specific methods of
-    /// the `HorizonClient` that define the type of request and response.
-    ///
-    /// # Remarks
-    ///
-    /// As a core utility function within `HorizonClient`, it centralizes the logic of sending
-    /// GET requests and handling responses. Modifications or enhancements to the request or
-    /// response handling logic should be implemented here to maintain consistency across the
-    /// client's interface.
-    ///
-    async fn get<R: Response>(&self, request: &impl Request) -> Result<R, String> {
-        // Construct the URL with potential query parameters.
-        let url = request.build_url(&self.base_url);
-
-        // Send the request and await the response.
-        let response = reqwest::get(&url).await.map_err(|e| e.to_string())?;
-
-        // Process the response and return the result.
-        let result: R = handle_response(response).await?;
-        Ok(result)
-    }
 
     /// Fetches all liquidity pools from the Stellar Horizon API.
     ///
@@ -2127,6 +2147,14 @@ impl HorizonClient {
         request: &PaymentsForTransactionRequest,
     ) -> Result<PaymentsResponse, String> {
         self.get::<PaymentsResponse>(request).await
+    }
+
+    // TODO: Documentation
+    pub async fn post_transaction(
+        &self,
+        request: &PostTransactionRequest<TransactionEnvelope>,
+    ) -> Result<TransactionResponse, String> {
+        self.post::<TransactionResponse>(request).await
     }
 }
 

--- a/stellar_rust_sdk/src/horizon_client.rs
+++ b/stellar_rust_sdk/src/horizon_client.rs
@@ -2187,7 +2187,43 @@ impl HorizonClient {
         self.get::<PaymentsResponse>(request).await
     }
 
-    // TODO: Documentation
+    /// Submits a transaction to the Horizon server.
+    ///
+    /// This asynchronous method submits a transaction to the Stellar network. It only takes a
+    /// single, required parameter: the signed transaction. Refer to the Transactions page for
+    /// details on how to craft a proper one. If you submit a transaction that has already been
+    /// included in a ledger, this endpoint will return the same response as would have been
+    /// returned for the original transaction submission. This allows for safe resubmission of
+    /// transactions in error scenarios, as highlighted in the error handling guide.
+    ///
+    /// # Arguments
+    /// * `request` - A reference to a [`PostTransactionRequest<TransactionEnvelope>`] instance, containing the
+    /// signed transaction to be submitted.
+    ///
+    /// # Returns
+    /// On successful execution, returns a `Result` containing a [`TransactionResponse`], which includes
+    /// the details of the submitted transaction. If the request fails, it returns an error within `Result`.
+    ///
+    /// # Usage
+    /// To use this method, create an instance of [`PostTransactionRequest`] and set the signed
+    /// transaction to be submitted.
+    /// ```
+    /// # use stellar_rs::transactions::prelude::*;
+    /// # use stellar_rs::models::Request;
+    /// # use stellar_rs::horizon_client::HorizonClient;
+    /// #
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
+    /// # let horizon_client = HorizonClient::new(base_url)
+    /// #    .expect("Failed to create Horizon Client");
+    /// let signed_transaction_xdr = "AAAAAgAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9wAABEwAAAAAAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsAAAAAAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFjRXhdigAAAAAAAAAAAAAAAAAA3b5KF6uk1w1fSKYLrzR8gF2lB+AHAi6oU6CaWhunAskAAAAXSHboAAAAAAAAAAAAAAAAAHfmNeMLin2aTUfxa530ZRn4zwRu7ROAQfUJeJco8HSCAAHGv1JjQAAAAAAAAAAAAAAAAAAAlRt2go9sp7E1a5ZWvr7vin4UPrFQThpQax1lOFm33AAAABdIdugAAAAAAAAAAAAAAAAAmv+knlR6JR2VqWeU0k/4FgvZ/tSV5DEY4gu0iOTKgpUAAAAXSHboAAAAAAAAAAAAAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAF0h26AAAAAABAAAAAACVG3aCj2ynsTVrlla+vu+KfhQ+sVBOGlBrHWU4WbfcAAAABgAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bf/////////8AAAABAAAAAJr/pJ5UeiUdlalnlNJP+BYL2f7UleQxGOILtIjkyoKVAAAABgAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bf/////////8AAAABAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAAQAAAAAAlRt2go9sp7E1a5ZWvr7vin4UPrFQThpQax1lOFm33AAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAJGE5yoAAAAAABAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAAQAAAACa/6SeVHolHZWpZ5TST/gWC9n+1JXkMRjiC7SI5MqClQAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAJGE5yoAAAAAAAAAAAAAAAAABKBB+2UBMP/abwcm/M1TXO+/JQWhPwkalgqizKmXyRIQx7qh6aAFYAAAAAAAAAAARW/AX3AAAAQDVB8fT2ZXF0PZqtZX9brK0kz+P4G8VKs1DkDklP6ULsvXRexXFBdH4xG8xRAsR1HJeEBH278hiBNNvUwNw6zgzGYc0bAAAAQLgZUU/oYGL7frWDQhJHhCQu9JmfqN03PrJq4/cJrN1OSUWXnmLc94sv8m2L+cxl2p0skr2Jxy+vt1Lcxkv7wAI4WbfcAAAAQHvZEVqlygIProf3jVTZohDWm2WUNrFAFXf1LctTqDCQBHph14Eo+APwrTURLLYTIvNoXeGzBKbL03SsOARWcQLkyoKVAAAAQHAvKv2/Ro4+cNh6bKQO/G9NNiUozYysGwG1GvJQkFjwy/OTsL6WBfuI0Oye84lVBVrQVk2EY1ERFhgdMpuFSg4=";
+    /// let request = PostTransactionRequest::new()
+    ///    .set_transaction_envelope_xdr(signed_transaction_xdr.to_string()).unwrap();
+    /// let response = horizon_client.post_transaction(&request).await;
+    /// # Ok({})
+    /// # }
+    /// ```
+    ///
     pub async fn post_transaction(
         &self,
         request: &PostTransactionRequest<TransactionEnvelope>,

--- a/stellar_rust_sdk/src/lib.rs
+++ b/stellar_rust_sdk/src/lib.rs
@@ -15,7 +15,7 @@
 //! stabilization.
 //!
 //! #### Supported endpoints:
-//! ![86%](https://progress-bar.dev/86/?width=200)
+//! ![93%](https://progress-bar.dev/93/?width=200)
 //! * Accounts
 //! * Assets
 //! * Claimable balance
@@ -29,10 +29,10 @@
 //! * Payments
 //! * Trades
 //! * Trade aggregations
+//! * Transactions
 //!
 //! #### Endpoints on the roadmap:
 //! * Paths
-//! * Transactions
 
 //!
 //! ## Example Usage

--- a/stellar_rust_sdk/src/models/mod.rs
+++ b/stellar_rust_sdk/src/models/mod.rs
@@ -7,7 +7,44 @@ pub mod prelude {
 }
 
 pub trait PostRequest {
+    /// Generates a vector of tuples, containing key/value pairs to be used in the request's formdata.
+    ///
+    /// This method is responsible for constructing the formdata body for an HTTP request.
+    /// It processes the request's parameters and converts them into a vector of tuples. These tuples
+    /// contain key/value pairs.
+    ///
+    /// # Returns
+    /// Returns a `Vector` representing the query parameters of the request. If the request does not
+    /// have any parameters, or if they are not applicable, this method may return an empty vector.
+    ///
+    /// # Usage
+    /// This method is typically used internally when creating the formdata body for the request.
+    ///
     fn get_body(&self) -> Vec<(String, String)>;
+
+    /// Constructs the complete URL for the HTTP request.
+    ///
+    /// This method combines the base URL of the Horizon server with the query parameters specific
+    /// to the request. It is responsible for assembling the full URL used to make the HTTP request
+    /// to the server. The method should appropriately format the URL, ensuring that the base URL
+    /// and query parameters are correctly concatenated.
+    ///
+    /// # Arguments
+    /// * `base_url` - A string slice representing the base URL of the Horizon server. This URL
+    ///   provides the foundational part of the request URL.
+    ///
+    /// # Returns
+    /// Returns a `String` representing the full URL for the request. This URL includes the base
+    /// URL and any query parameters, correctly formatted for use in an HTTP request.
+    ///
+    /// # Usage
+    /// This method is typically called when an HTTP request is being prepared. The returned URL
+    /// is used as the target for the request.
+    ///
+    /// Implementors of this method should ensure that the full URL is correctly structured,
+    /// particularly in cases where the base URL has specific path components or the request
+    /// includes complex query parameters.
+    ///
     fn build_url(&self, base_url: &str) -> String;
 
 }

--- a/stellar_rust_sdk/src/models/mod.rs
+++ b/stellar_rust_sdk/src/models/mod.rs
@@ -6,6 +6,12 @@ pub mod prelude {
     pub use super::Response;
 }
 
+pub trait PostRequest {
+    fn get_body(&self) -> Vec<(String, String)>;
+    fn build_url(&self, base_url: &str) -> String;
+
+}
+
 /// Defines methods for creating HTTP requests to the Horizon server.
 ///
 /// Implementors of this trait represent different types of requests that can be made to the server.

--- a/stellar_rust_sdk/src/models/mod.rs
+++ b/stellar_rust_sdk/src/models/mod.rs
@@ -6,7 +6,7 @@ pub mod prelude {
     pub use super::Response;
 }
 
-pub trait PostRequest {
+pub(crate) trait PostRequest {
     /// Generates a vector of tuples, containing key/value pairs to be used in the request's formdata.
     ///
     /// This method is responsible for constructing the formdata body for an HTTP request.
@@ -41,7 +41,7 @@ pub trait PostRequest {
     /// This method is typically called when an HTTP request is being prepared. The returned URL
     /// is used as the target for the request.
     ///
-    /// Implementors of this method should ensure that the full URL is correctly structured,
+    /// Implementers of this method should ensure that the full URL is correctly structured,
     /// particularly in cases where the base URL has specific path components or the request
     /// includes complex query parameters.
     ///
@@ -51,11 +51,11 @@ pub trait PostRequest {
 
 /// Defines methods for creating HTTP requests to the Horizon server.
 ///
-/// Implementors of this trait represent different types of requests that can be made to the server.
+/// Implementers of this trait represent different types of requests that can be made to the server.
 /// The trait provides methods for assembling the request's query parameters and building the
 /// full URL for the request.
 ///
-/// Implementors of this trait should provide the specific logic for these methods based on the
+/// Implementers of this trait should provide the specific logic for these methods based on the
 /// type of request they represent.
 ///
 pub trait Request {

--- a/stellar_rust_sdk/src/models/mod.rs
+++ b/stellar_rust_sdk/src/models/mod.rs
@@ -46,7 +46,6 @@ pub(crate) trait PostRequest {
     /// includes complex query parameters.
     ///
     fn build_url(&self, base_url: &str) -> String;
-
 }
 
 /// Defines methods for creating HTTP requests to the Horizon server.

--- a/stellar_rust_sdk/src/transactions/mod.rs
+++ b/stellar_rust_sdk/src/transactions/mod.rs
@@ -8,6 +8,9 @@
 ///
 pub mod single_transaction_request;
 
+// TODO: Documentation
+pub mod post_transaction_request;
+
 /// Provides the `AllTransactionsRequest`.
 ///
 /// # Usage
@@ -19,7 +22,7 @@ pub mod single_transaction_request;
 pub mod all_transactions_request;
 
 /// Provides the `TransactionsForAccountRequest`.
-///
+/// 
 /// # Usage
 /// This module provides the `TransactionsForAccountRequest` struct, specifically designed for
 /// constructing requests to query information about all successful transactions for a given account from the Horizon
@@ -97,6 +100,7 @@ pub(crate) static TRANSACTIONS_PATH: &str = "transactions";
 /// let single_transactions_request = SingleTransactionRequest::new();
 /// ```
 pub mod prelude {
+    pub use super::post_transaction_request::*;
     pub use super::all_transactions_request::*;
     pub use super::response::*;
     pub use super::single_transaction_request::*;
@@ -549,5 +553,25 @@ pub mod test {
                 .min_time(),
             MIN_TIME
         );
+    }
+
+    #[tokio::test]
+    async fn test_post() {
+
+        const XDR: &str = "AAAAAgAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9wAABEwAAAAAAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsAAAAAAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFjRXhdigAAAAAAAAAAAAAAAAAA3b5KF6uk1w1fSKYLrzR8gF2lB+AHAi6oU6CaWhunAskAAAAXSHboAAAAAAAAAAAAAAAAAHfmNeMLin2aTUfxa530ZRn4zwRu7ROAQfUJeJco8HSCAAHGv1JjQAAAAAAAAAAAAAAAAAAAlRt2go9sp7E1a5ZWvr7vin4UPrFQThpQax1lOFm33AAAABdIdugAAAAAAAAAAAAAAAAAmv+knlR6JR2VqWeU0k/4FgvZ/tSV5DEY4gu0iOTKgpUAAAAXSHboAAAAAAAAAAAAAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAF0h26AAAAAABAAAAAACVG3aCj2ynsTVrlla+vu+KfhQ+sVBOGlBrHWU4WbfcAAAABgAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bf/////////8AAAABAAAAAJr/pJ5UeiUdlalnlNJP+BYL2f7UleQxGOILtIjkyoKVAAAABgAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bf/////////8AAAABAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAAQAAAAAAlRt2go9sp7E1a5ZWvr7vin4UPrFQThpQax1lOFm33AAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAJGE5yoAAAAAABAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAAQAAAACa/6SeVHolHZWpZ5TST/gWC9n+1JXkMRjiC7SI5MqClQAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAJGE5yoAAAAAAAAAAAAAAAAABKBB+2UBMP/abwcm/M1TXO+/JQWhPwkalgqizKmXyRIQx7qh6aAFYAAAAAAAAAAARW/AX3AAAAQDVB8fT2ZXF0PZqtZX9brK0kz+P4G8VKs1DkDklP6ULsvXRexXFBdH4xG8xRAsR1HJeEBH278hiBNNvUwNw6zgzGYc0bAAAAQLgZUU/oYGL7frWDQhJHhCQu9JmfqN03PrJq4/cJrN1OSUWXnmLc94sv8m2L+cxl2p0skr2Jxy+vt1Lcxkv7wAI4WbfcAAAAQHvZEVqlygIProf3jVTZohDWm2WUNrFAFXf1LctTqDCQBHph14Eo+APwrTURLLYTIvNoXeGzBKbL03SsOARWcQLkyoKVAAAAQHAvKv2/Ro4+cNh6bKQO/G9NNiUozYysGwG1GvJQkFjwy/OTsL6WBfuI0Oye84lVBVrQVk2EY1ERFhgdMpuFSg4=";
+        let horizon_client =
+            HorizonClient::new("https://horizon-testnet.stellar.org"
+            .to_string())
+            .unwrap();
+
+        let request = PostTransactionRequest::new()
+            .set_transaction_envelope_xdr(XDR.to_string())
+            .unwrap();
+
+        let response = horizon_client
+            .post_transaction(&request)
+            .await;
+
+        println!("{:?}", response);
     }
 }

--- a/stellar_rust_sdk/src/transactions/mod.rs
+++ b/stellar_rust_sdk/src/transactions/mod.rs
@@ -111,6 +111,7 @@ pub(crate) static TRANSACTIONS_PATH: &str = "transactions";
 /// ```
 pub mod prelude {
     pub use super::all_transactions_request::*;
+    pub use super::post_transaction_request::*;
     pub use super::response::*;
     pub use super::single_transaction_request::*;
     pub use super::transactions_for_account_request::*;

--- a/stellar_rust_sdk/src/transactions/mod.rs
+++ b/stellar_rust_sdk/src/transactions/mod.rs
@@ -28,7 +28,7 @@ pub mod post_transaction_request;
 pub mod all_transactions_request;
 
 /// Provides the `TransactionsForAccountRequest`.
-/// 
+///
 /// # Usage
 /// This module provides the `TransactionsForAccountRequest` struct, specifically designed for
 /// constructing requests to query information about all successful transactions for a given account from the Horizon
@@ -110,7 +110,6 @@ pub(crate) static TRANSACTIONS_PATH: &str = "transactions";
 /// let single_transactions_request = SingleTransactionRequest::new();
 /// ```
 pub mod prelude {
-    pub use super::post_transaction_request::*;
     pub use super::all_transactions_request::*;
     pub use super::response::*;
     pub use super::single_transaction_request::*;
@@ -574,8 +573,10 @@ pub mod test {
         const LINK_LEDGER: &str = "https://horizon-testnet.stellar.org/ledgers/539";
         const LINK_OPERATIONS: &str = "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020/operations{?cursor,limit,order}";
         const LINK_EFFECTS: &str = "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020/effects{?cursor,limit,order}";
-        const LINK_PRECEDES: &str = "https://horizon-testnet.stellar.org/transactions?order=asc&cursor=2314987376640";
-        const LINK_SUCCEEDS: &str = "https://horizon-testnet.stellar.org/transactions?order=desc&cursor=2314987376640";
+        const LINK_PRECEDES: &str =
+            "https://horizon-testnet.stellar.org/transactions?order=asc&cursor=2314987376640";
+        const LINK_SUCCEEDS: &str =
+            "https://horizon-testnet.stellar.org/transactions?order=desc&cursor=2314987376640";
         const LINK_TRANSACTION: &str = "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
         const ID: &str = "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
         const PAGING_TOKEN: &str = "2314987376640";
@@ -595,43 +596,71 @@ pub mod test {
         const MIN_TIME: &str = "0";
 
         let horizon_client =
-            HorizonClient::new("https://horizon-testnet.stellar.org"
-            .to_string())
-            .unwrap();
+            HorizonClient::new("https://horizon-testnet.stellar.org".to_string()).unwrap();
 
         let request = PostTransactionRequest::new()
-            .set_transaction_envelope_xdr(REQUEST_XDR.to_string())
+            .set_transaction_envelope_xdr(REQUEST_XDR)
             .unwrap();
 
-        let response = horizon_client
-            .post_transaction(&request)
-            .await;
+        let response = horizon_client.post_transaction(&request).await;
 
-            assert!(response.clone().is_ok());
-            let record = response.unwrap();
-            assert_eq!(record.links().self_link().href().as_ref().unwrap(), LINK_SELF);
-            assert_eq!(record.links().account().href().as_ref().unwrap(), LINK_ACCOUNT);
-            assert_eq!(record.links().ledger().href().as_ref().unwrap(), LINK_LEDGER);
-            assert_eq!(record.links().operations().href().as_ref().unwrap(), LINK_OPERATIONS);
-            assert_eq!(record.links().effects().href().as_ref().unwrap(), LINK_EFFECTS);
-            assert_eq!(record.links().precedes().href().as_ref().unwrap(), LINK_PRECEDES);
-            assert_eq!(record.links().succeeds().href().as_ref().unwrap(), LINK_SUCCEEDS);
-            assert_eq!(record.links().transaction().href().as_ref().unwrap(), LINK_TRANSACTION);
-            assert_eq!(record.id(), ID);
-            assert_eq!(record.paging_token(), PAGING_TOKEN);
-            assert_eq!(record.successful(), SUCCESSFUL);
-            assert_eq!(record.hash(), HASH);
-            assert_eq!(record.ledger(), LEDGER);
-            assert_eq!(record.created_at(), CREATED_AT);
-            assert_eq!(record.source_account(), SOURCE_ACCOUNT);
-            assert_eq!(record.source_account_sequence(), SOURCE_ACCOUNT_SEQUENCE);
-            assert_eq!(record.fee_account(), FEE_ACCOUNT);
-            assert_eq!(record.fee_charged(), FEE_CHARGED);
-            assert_eq!(record.max_fee(), MAX_FEE);
-            assert_eq!(record.operation_count(), OPERATION_COUNT);
-            assert_eq!(record.memo_type(), MEMO_TYPE);
-            assert_eq!(record.signatures()[0], SIGNATURE); // Check only the first signature of the vector
-            assert_eq!(record.valid_after().as_ref().unwrap(), VALID_AFTER);
-            assert_eq!(record.preconditions().as_ref().unwrap().timebounds().min_time(), MIN_TIME);
+        assert!(response.clone().is_ok());
+        let record = response.unwrap();
+        assert_eq!(
+            record.links().self_link().href().as_ref().unwrap(),
+            LINK_SELF
+        );
+        assert_eq!(
+            record.links().account().href().as_ref().unwrap(),
+            LINK_ACCOUNT
+        );
+        assert_eq!(
+            record.links().ledger().href().as_ref().unwrap(),
+            LINK_LEDGER
+        );
+        assert_eq!(
+            record.links().operations().href().as_ref().unwrap(),
+            LINK_OPERATIONS
+        );
+        assert_eq!(
+            record.links().effects().href().as_ref().unwrap(),
+            LINK_EFFECTS
+        );
+        assert_eq!(
+            record.links().precedes().href().as_ref().unwrap(),
+            LINK_PRECEDES
+        );
+        assert_eq!(
+            record.links().succeeds().href().as_ref().unwrap(),
+            LINK_SUCCEEDS
+        );
+        assert_eq!(
+            record.links().transaction().href().as_ref().unwrap(),
+            LINK_TRANSACTION
+        );
+        assert_eq!(record.id(), ID);
+        assert_eq!(record.paging_token(), PAGING_TOKEN);
+        assert_eq!(record.successful(), SUCCESSFUL);
+        assert_eq!(record.hash(), HASH);
+        assert_eq!(record.ledger(), LEDGER);
+        assert_eq!(record.created_at(), CREATED_AT);
+        assert_eq!(record.source_account(), SOURCE_ACCOUNT);
+        assert_eq!(record.source_account_sequence(), SOURCE_ACCOUNT_SEQUENCE);
+        assert_eq!(record.fee_account(), FEE_ACCOUNT);
+        assert_eq!(record.fee_charged(), FEE_CHARGED);
+        assert_eq!(record.max_fee(), MAX_FEE);
+        assert_eq!(record.operation_count(), OPERATION_COUNT);
+        assert_eq!(record.memo_type(), MEMO_TYPE);
+        assert_eq!(record.signatures()[0], SIGNATURE); // Check only the first signature of the vector
+        assert_eq!(record.valid_after().as_ref().unwrap(), VALID_AFTER);
+        assert_eq!(
+            record
+                .preconditions()
+                .as_ref()
+                .unwrap()
+                .timebounds()
+                .min_time(),
+            MIN_TIME
+        );
     }
 }

--- a/stellar_rust_sdk/src/transactions/mod.rs
+++ b/stellar_rust_sdk/src/transactions/mod.rs
@@ -8,7 +8,13 @@
 ///
 pub mod single_transaction_request;
 
-// TODO: Documentation
+/// Provides the `PostTransactionRequest`.
+///
+/// # Usage
+/// This module provides the `PostTransactionRequest` struct, specifically designed for
+/// constructing requests to post a new transaction to the Horizon server.
+/// It is tailored for use with the [`HorizonClient::post_transaction`](crate::horizon_client::HorizonClient::post_transaction) method.
+///
 pub mod post_transaction_request;
 
 /// Provides the `AllTransactionsRequest`.
@@ -87,7 +93,11 @@ pub(crate) static TRANSACTIONS_PATH: &str = "transactions";
 /// The `prelude` includes the following re-exports:
 ///
 /// * From `single_transaction_request`: All items (e.g. `SingleTransactionRequest`).
+/// * From `post_transaction_request`: All items (e.g. `PostTransactionRequest`, `TransactionEnvelope`, `NoTransactionEnvelope`).
 /// * From `all_transactions_request`: All items (e.g. `AllTransactionsRequest`).
+/// * From `transactions_for_account_request`: All items (e.g. `TransactionsForAccountRequest`, `TransactionsAccountId`, etc.).
+/// * From `transactions_for_ledger_request`: All items (e.g. `TransactionsForLedgerRequest`, `TransactionsLedgerId`, etc.).
+/// * From `transactions_for_liquidity_pool_request`: All items (e.g. `TransactionsForLiquidityPoolRequest`, `TransactionsLiquidityPoolId`, etc.).
 /// * From `response`: All items (e.g. `SingleTransactionResponse`, `Preconditions`, etc.).
 ///
 /// # Example
@@ -556,22 +566,72 @@ pub mod test {
     }
 
     #[tokio::test]
-    async fn test_post() {
+    async fn test_post_transaction() {
+        const REQUEST_XDR: &str = "AAAAAgAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9wAABEwAAAAAAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsAAAAAAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFjRXhdigAAAAAAAAAAAAAAAAAA3b5KF6uk1w1fSKYLrzR8gF2lB+AHAi6oU6CaWhunAskAAAAXSHboAAAAAAAAAAAAAAAAAHfmNeMLin2aTUfxa530ZRn4zwRu7ROAQfUJeJco8HSCAAHGv1JjQAAAAAAAAAAAAAAAAAAAlRt2go9sp7E1a5ZWvr7vin4UPrFQThpQax1lOFm33AAAABdIdugAAAAAAAAAAAAAAAAAmv+knlR6JR2VqWeU0k/4FgvZ/tSV5DEY4gu0iOTKgpUAAAAXSHboAAAAAAAAAAAAAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAF0h26AAAAAABAAAAAACVG3aCj2ynsTVrlla+vu+KfhQ+sVBOGlBrHWU4WbfcAAAABgAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bf/////////8AAAABAAAAAJr/pJ5UeiUdlalnlNJP+BYL2f7UleQxGOILtIjkyoKVAAAABgAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bf/////////8AAAABAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAAQAAAAAAlRt2go9sp7E1a5ZWvr7vin4UPrFQThpQax1lOFm33AAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAJGE5yoAAAAAABAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAAQAAAACa/6SeVHolHZWpZ5TST/gWC9n+1JXkMRjiC7SI5MqClQAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAJGE5yoAAAAAAAAAAAAAAAAABKBB+2UBMP/abwcm/M1TXO+/JQWhPwkalgqizKmXyRIQx7qh6aAFYAAAAAAAAAAARW/AX3AAAAQDVB8fT2ZXF0PZqtZX9brK0kz+P4G8VKs1DkDklP6ULsvXRexXFBdH4xG8xRAsR1HJeEBH278hiBNNvUwNw6zgzGYc0bAAAAQLgZUU/oYGL7frWDQhJHhCQu9JmfqN03PrJq4/cJrN1OSUWXnmLc94sv8m2L+cxl2p0skr2Jxy+vt1Lcxkv7wAI4WbfcAAAAQHvZEVqlygIProf3jVTZohDWm2WUNrFAFXf1LctTqDCQBHph14Eo+APwrTURLLYTIvNoXeGzBKbL03SsOARWcQLkyoKVAAAAQHAvKv2/Ro4+cNh6bKQO/G9NNiUozYysGwG1GvJQkFjwy/OTsL6WBfuI0Oye84lVBVrQVk2EY1ERFhgdMpuFSg4=";
 
-        const XDR: &str = "AAAAAgAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9wAABEwAAAAAAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAsAAAAAAAAAAAAAAAAQfdFrLDgzSIIugR73qs8U0ZiKbwBUclTTPh5thlbgnAFjRXhdigAAAAAAAAAAAAAAAAAA3b5KF6uk1w1fSKYLrzR8gF2lB+AHAi6oU6CaWhunAskAAAAXSHboAAAAAAAAAAAAAAAAAHfmNeMLin2aTUfxa530ZRn4zwRu7ROAQfUJeJco8HSCAAHGv1JjQAAAAAAAAAAAAAAAAAAAlRt2go9sp7E1a5ZWvr7vin4UPrFQThpQax1lOFm33AAAABdIdugAAAAAAAAAAAAAAAAAmv+knlR6JR2VqWeU0k/4FgvZ/tSV5DEY4gu0iOTKgpUAAAAXSHboAAAAAAAAAAAAAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAF0h26AAAAAABAAAAAACVG3aCj2ynsTVrlla+vu+KfhQ+sVBOGlBrHWU4WbfcAAAABgAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bf/////////8AAAABAAAAAJr/pJ5UeiUdlalnlNJP+BYL2f7UleQxGOILtIjkyoKVAAAABgAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bf/////////8AAAABAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAAQAAAAAAlRt2go9sp7E1a5ZWvr7vin4UPrFQThpQax1lOFm33AAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAJGE5yoAAAAAABAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAAAQAAAACa/6SeVHolHZWpZ5TST/gWC9n+1JXkMRjiC7SI5MqClQAAAAFURVNUAAAAANpaWLojuOtfC0cmMh+DvQTfPDrkfXhblQTdFXrGYc0bAAAJGE5yoAAAAAAAAAAAAAAAAABKBB+2UBMP/abwcm/M1TXO+/JQWhPwkalgqizKmXyRIQx7qh6aAFYAAAAAAAAAAARW/AX3AAAAQDVB8fT2ZXF0PZqtZX9brK0kz+P4G8VKs1DkDklP6ULsvXRexXFBdH4xG8xRAsR1HJeEBH278hiBNNvUwNw6zgzGYc0bAAAAQLgZUU/oYGL7frWDQhJHhCQu9JmfqN03PrJq4/cJrN1OSUWXnmLc94sv8m2L+cxl2p0skr2Jxy+vt1Lcxkv7wAI4WbfcAAAAQHvZEVqlygIProf3jVTZohDWm2WUNrFAFXf1LctTqDCQBHph14Eo+APwrTURLLYTIvNoXeGzBKbL03SsOARWcQLkyoKVAAAAQHAvKv2/Ro4+cNh6bKQO/G9NNiUozYysGwG1GvJQkFjwy/OTsL6WBfuI0Oye84lVBVrQVk2EY1ERFhgdMpuFSg4=";
+        const LINK_SELF: &str = "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
+        const LINK_ACCOUNT: &str = "https://horizon-testnet.stellar.org/accounts/GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
+        const LINK_LEDGER: &str = "https://horizon-testnet.stellar.org/ledgers/539";
+        const LINK_OPERATIONS: &str = "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020/operations{?cursor,limit,order}";
+        const LINK_EFFECTS: &str = "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020/effects{?cursor,limit,order}";
+        const LINK_PRECEDES: &str = "https://horizon-testnet.stellar.org/transactions?order=asc&cursor=2314987376640";
+        const LINK_SUCCEEDS: &str = "https://horizon-testnet.stellar.org/transactions?order=desc&cursor=2314987376640";
+        const LINK_TRANSACTION: &str = "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
+        const ID: &str = "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
+        const PAGING_TOKEN: &str = "2314987376640";
+        const SUCCESSFUL: &bool = &true;
+        const HASH: &str = "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
+        const LEDGER: &i64 = &539;
+        const CREATED_AT: &str = "2024-06-11T21:36:12Z";
+        const SOURCE_ACCOUNT: &str = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
+        const SOURCE_ACCOUNT_SEQUENCE: &str = "1";
+        const FEE_ACCOUNT: &str = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
+        const FEE_CHARGED: &str = "1100";
+        const MAX_FEE: &str = "1100";
+        const OPERATION_COUNT: &i64 = &11;
+        const MEMO_TYPE: &str = "none";
+        const SIGNATURE: &str = "NUHx9PZlcXQ9mq1lf1usrSTP4/gbxUqzUOQOSU/pQuy9dF7FcUF0fjEbzFECxHUcl4QEfbvyGIE029TA3DrODA==";
+        const VALID_AFTER: &str = "1970-01-01T00:00:00Z";
+        const MIN_TIME: &str = "0";
+
         let horizon_client =
             HorizonClient::new("https://horizon-testnet.stellar.org"
             .to_string())
             .unwrap();
 
         let request = PostTransactionRequest::new()
-            .set_transaction_envelope_xdr(XDR.to_string())
+            .set_transaction_envelope_xdr(REQUEST_XDR.to_string())
             .unwrap();
 
         let response = horizon_client
             .post_transaction(&request)
             .await;
 
-        println!("{:?}", response);
+            assert!(response.clone().is_ok());
+            let record = response.unwrap();
+            assert_eq!(record.links().self_link().href().as_ref().unwrap(), LINK_SELF);
+            assert_eq!(record.links().account().href().as_ref().unwrap(), LINK_ACCOUNT);
+            assert_eq!(record.links().ledger().href().as_ref().unwrap(), LINK_LEDGER);
+            assert_eq!(record.links().operations().href().as_ref().unwrap(), LINK_OPERATIONS);
+            assert_eq!(record.links().effects().href().as_ref().unwrap(), LINK_EFFECTS);
+            assert_eq!(record.links().precedes().href().as_ref().unwrap(), LINK_PRECEDES);
+            assert_eq!(record.links().succeeds().href().as_ref().unwrap(), LINK_SUCCEEDS);
+            assert_eq!(record.links().transaction().href().as_ref().unwrap(), LINK_TRANSACTION);
+            assert_eq!(record.id(), ID);
+            assert_eq!(record.paging_token(), PAGING_TOKEN);
+            assert_eq!(record.successful(), SUCCESSFUL);
+            assert_eq!(record.hash(), HASH);
+            assert_eq!(record.ledger(), LEDGER);
+            assert_eq!(record.created_at(), CREATED_AT);
+            assert_eq!(record.source_account(), SOURCE_ACCOUNT);
+            assert_eq!(record.source_account_sequence(), SOURCE_ACCOUNT_SEQUENCE);
+            assert_eq!(record.fee_account(), FEE_ACCOUNT);
+            assert_eq!(record.fee_charged(), FEE_CHARGED);
+            assert_eq!(record.max_fee(), MAX_FEE);
+            assert_eq!(record.operation_count(), OPERATION_COUNT);
+            assert_eq!(record.memo_type(), MEMO_TYPE);
+            assert_eq!(record.signatures()[0], SIGNATURE); // Check only the first signature of the vector
+            assert_eq!(record.valid_after().as_ref().unwrap(), VALID_AFTER);
+            assert_eq!(record.preconditions().as_ref().unwrap().timebounds().min_time(), MIN_TIME);
     }
 }

--- a/stellar_rust_sdk/src/transactions/post_transaction_request.rs
+++ b/stellar_rust_sdk/src/transactions/post_transaction_request.rs
@@ -1,0 +1,55 @@
+use crate::models::*;
+
+/// Represents the transaction evenlope XDR.
+#[derive(Default, Clone)]
+pub struct TransactionEnvelope(String);
+
+/// Represents the absence of a transaction evenlope XDR.
+#[derive(Default, Clone)]
+pub struct NoTransactionEnvelope;
+
+#[derive(Default)]
+pub struct PostTransactionRequest<T> {
+    /// todo serde rename -> tx
+    transaction_envelope_xdr: T,
+}
+
+impl PostTransactionRequest<NoTransactionEnvelope> {
+    /// Creates a new `SingleTransactionRequest` with default parameters.
+    pub fn new() -> Self {
+        PostTransactionRequest::default()
+    }
+
+    /// Sets the transaction hash for the request.
+    /// 
+    /// # Arguments
+    /// * `transaction_hash` - A `String` specifying the operation hash.
+    /// 
+    pub fn set_transaction_envelope_xdr(
+        self,
+        transaction_envelope_xdr: String,
+    ) -> Result<PostTransactionRequest<TransactionEnvelope>, String> {
+        // // TODO: does a XDR have a fixed length?
+        Ok(PostTransactionRequest {transaction_envelope_xdr: TransactionEnvelope(transaction_envelope_xdr)})
+        // match transaction_envelope_xdr.len() {
+        //     64 => Ok(PostTransactionRequest {transaction_envelope_xdr: TransactionEnvelope(transaction_envelope_xdr)}),
+        //     _ => Err("Transaction hash must be 64 characters long".to_string())
+        // }
+    }
+}
+
+impl PostRequest for PostTransactionRequest<TransactionEnvelope> {
+    fn get_body(&self) -> Vec<(String, String)> {
+        vec![("tx".to_string(), self.transaction_envelope_xdr.0.to_string())]
+    }
+
+    fn build_url(&self, base_url: &str) -> String {
+        // This URL is not built with query parameters, but with the transaction hash as addition to the path.
+        // Therefore there is no `?` but a `/` in the formatted string.
+        format!(
+            "{}/{}",
+            base_url,
+            super::TRANSACTIONS_PATH
+        )
+    }
+}

--- a/stellar_rust_sdk/src/transactions/post_transaction_request.rs
+++ b/stellar_rust_sdk/src/transactions/post_transaction_request.rs
@@ -21,15 +21,17 @@ impl PostTransactionRequest<NoTransactionEnvelope> {
     }
 
     /// Sets the transaction envelope for the request.
-    /// 
+    ///
     /// # Arguments
     /// * `transaction_envelope_xdr` - A `String` specifying the transaction envelope XDR.
-    /// 
+    ///
     pub fn set_transaction_envelope_xdr(
         self,
-        transaction_envelope_xdr: String,
+        transaction_envelope_xdr: impl Into<String>,
     ) -> Result<PostTransactionRequest<TransactionEnvelope>, String> {
-        Ok(PostTransactionRequest {transaction_envelope_xdr: TransactionEnvelope(transaction_envelope_xdr)})
+        Ok(PostTransactionRequest {
+            transaction_envelope_xdr: TransactionEnvelope(transaction_envelope_xdr.into()),
+        })
     }
 }
 
@@ -37,15 +39,14 @@ impl PostRequest for PostTransactionRequest<TransactionEnvelope> {
     fn get_body(&self) -> Vec<(String, String)> {
         // Return a vector containing a tuple with a key/value pair, to be used in the request's formdata.
         // Since the request has one parameter, a vector with only 1 tuple is returned.
-        vec![("tx".to_string(), self.transaction_envelope_xdr.0.to_string())]
+        vec![(
+            "tx".to_string(),
+            self.transaction_envelope_xdr.0.to_string(),
+        )]
     }
 
     fn build_url(&self, base_url: &str) -> String {
         // This URL is not built with query parameters, but uses formdata, which is POSTed to the transactions API endpoint.
-        format!(
-            "{}/{}",
-            base_url,
-            super::TRANSACTIONS_PATH
-        )
+        format!("{}/{}", base_url, super::TRANSACTIONS_PATH)
     }
 }

--- a/stellar_rust_sdk/src/transactions/post_transaction_request.rs
+++ b/stellar_rust_sdk/src/transactions/post_transaction_request.rs
@@ -1,51 +1,47 @@
 use crate::models::*;
 
-/// Represents the transaction evenlope XDR.
+/// Represents the transaction envelope XDR.
 #[derive(Default, Clone)]
 pub struct TransactionEnvelope(String);
 
-/// Represents the absence of a transaction evenlope XDR.
+/// Represents the absence of a transaction envelope XDR.
 #[derive(Default, Clone)]
 pub struct NoTransactionEnvelope;
 
 #[derive(Default)]
 pub struct PostTransactionRequest<T> {
-    /// todo serde rename -> tx
+    /// A base64-encoded string containing the transaction envelope XDR.
     transaction_envelope_xdr: T,
 }
 
 impl PostTransactionRequest<NoTransactionEnvelope> {
-    /// Creates a new `SingleTransactionRequest` with default parameters.
+    /// Creates a new `PostTransactionRequest` with default parameters.
     pub fn new() -> Self {
         PostTransactionRequest::default()
     }
 
-    /// Sets the transaction hash for the request.
+    /// Sets the transaction envelope for the request.
     /// 
     /// # Arguments
-    /// * `transaction_hash` - A `String` specifying the operation hash.
+    /// * `transaction_envelope_xdr` - A `String` specifying the transaction envelope XDR.
     /// 
     pub fn set_transaction_envelope_xdr(
         self,
         transaction_envelope_xdr: String,
     ) -> Result<PostTransactionRequest<TransactionEnvelope>, String> {
-        // // TODO: does a XDR have a fixed length?
         Ok(PostTransactionRequest {transaction_envelope_xdr: TransactionEnvelope(transaction_envelope_xdr)})
-        // match transaction_envelope_xdr.len() {
-        //     64 => Ok(PostTransactionRequest {transaction_envelope_xdr: TransactionEnvelope(transaction_envelope_xdr)}),
-        //     _ => Err("Transaction hash must be 64 characters long".to_string())
-        // }
     }
 }
 
 impl PostRequest for PostTransactionRequest<TransactionEnvelope> {
     fn get_body(&self) -> Vec<(String, String)> {
+        // Return a vector containing a tuple with a key/value pair, to be used in the request's formdata.
+        // Since the request has one parameter, a vector with only 1 tuple is returned.
         vec![("tx".to_string(), self.transaction_envelope_xdr.0.to_string())]
     }
 
     fn build_url(&self, base_url: &str) -> String {
-        // This URL is not built with query parameters, but with the transaction hash as addition to the path.
-        // Therefore there is no `?` but a `/` in the formatted string.
+        // This URL is not built with query parameters, but uses formdata, which is POSTed to the transactions API endpoint.
         format!(
             "{}/{}",
             base_url,


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes #57. Adds the _Post Transaction_ endpoint, and completes the _Transactions_ endpoint group.

For this endpoint, a new request type `PostRequest` has been created, in addition to `Request`. We could discuss a naming convention, and perhaps change `Request` to `GetRequest`.

Note: this PR includes some testnet value updates. During the updating of these values, it became clear some response values in the _Trades_ endpoint are optional. These fields have been updated in the response struct.

### :memo: Links to relevant issues/docs
https://developers.stellar.org/docs/data/horizon/api-reference/submit-a-transaction

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current main
