### PR TITLE
'Operations for Transactions' endpoint

### DIFF
--- a/stellar_rust_sdk/src/horizon_client.rs
+++ b/stellar_rust_sdk/src/horizon_client.rs
@@ -1066,7 +1066,7 @@ impl HorizonClient {
     /// let request = OperationsForAccountRequest::new()
     ///   .set_limit(2).unwrap();
     ///
-    /// let response = horizon_client.get_operation_for_account(&request).await;
+    /// let response = horizon_client.get_operations_for_account(&request).await;
     ///
     /// // Access the payments
     /// if let Ok(operations_for_account_response) = response {
@@ -1222,10 +1222,10 @@ impl HorizonClient {
     ///
     /// // Access the operations
     /// if let Ok(operations_for_transaction_response) = response {
-    ///  for operation in operations_for_transaction_response.embedded().records() {
-    ///   println!("Operation ID: {}", operation.id());
-    /// // Further processing...
-    /// }
+    ///     for operation in operations_for_transaction_response.embedded().records() {
+    ///         println!("Operation ID: {}", operation.id());
+    ///         // Further processing...
+    ///     }
     /// }
     /// # Ok({})
     /// # }

--- a/stellar_rust_sdk/src/horizon_client.rs
+++ b/stellar_rust_sdk/src/horizon_client.rs
@@ -24,7 +24,7 @@ use crate::{
         operations_for_account_request::OperationsForAccountRequest,
         prelude::{
             AllOperationsRequest, OperationResponse, OperationsForLedgerRequest,
-            OperationsForLiquidityPoolRequest,
+            OperationsForLiquidityPoolRequest, OperationsForTransactionRequest,
         },
         response::Operation,
         single_operation_request::{OperationId, SingleOperationRequest},
@@ -1046,7 +1046,7 @@ impl HorizonClient {
     ///
     /// # Returns
     ///
-    /// On successful execution, returns a `Result` containing a [`OperationsForAccountRequest`], which includes
+    /// On successful execution, returns a `Result` containing a [`OperationResponse`], which includes
     /// the list of all operations obtained from the Horizon server. If the request fails, it returns an error within `Result`.
     ///
     /// # Usage
@@ -1079,13 +1079,57 @@ impl HorizonClient {
     /// # }
     /// ```
     ///
-    pub async fn get_operation_for_account(
+    pub async fn get_operations_for_account(
         &self,
         request: &OperationsForAccountRequest,
     ) -> Result<OperationResponse, String> {
         self.get::<OperationResponse>(request).await
     }
 
+    /// Retrieves a list of all operations for a ledger from the Horizon server.
+    ///
+    /// This asynchronous method fetches a list of all operations for a ledger from the Horizon server.
+    /// It requires an [`OperationsForLedgerRequest`] to specify the optional query parameters.
+    ///
+    /// # Arguments
+    /// * `request` - A reference to an [`OperationsForLedgerRequest`] instance, containing the
+    /// parameters for the operations for ledger request.
+    ///
+    /// # Returns
+    ///
+    /// On successful execution, returns a `Result` containing a [`OperationResponse`], which includes
+    /// the list of all operations obtained from the Horizon server. If the request fails, it returns an error within `Result`.
+    ///
+    /// # Usage
+    /// To use this method, create an instance of [`OperationsForLedgerRequest`] and set any desired
+    /// filters or parameters.
+    ///
+    /// ```
+    /// # use stellar_rs::operations::prelude::*;
+    /// # use stellar_rs::models::Request;
+    /// # use stellar_rs::horizon_client::HorizonClient;
+    /// # use crate::stellar_rs::Paginatable;
+    /// #
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
+    /// # let horizon_client = HorizonClient::new(base_url)
+    /// #    .expect("Failed to create Horizon Client");
+    /// let request = OperationsForLedgerRequest::new()
+    ///   .set_limit(2).unwrap();
+    ///
+    /// let response = horizon_client.get_operations_for_ledger(&request).await;
+    ///
+    /// // Access the payments
+    /// if let Ok(operations_for_ledger_response) = response {
+    ///   for operation in operations_for_ledger_response.embedded().records() {
+    ///    println!("operation ID: {}", operation.id());
+    ///  // Further processing...
+    /// }
+    /// }
+    /// # Ok({})
+    /// # }
+    /// ```
+    ///
     pub async fn get_operations_for_ledger(
         &self,
         request: &OperationsForLedgerRequest,
@@ -1093,6 +1137,107 @@ impl HorizonClient {
         self.get::<OperationResponse>(request).await
     }
 
+    /// Retrieves a list of all operations for a specific liquidity pool from the Horizon server.
+    ///
+    /// This asynchronous method fetches a list of all operations for a specific liquidity pool from the Horizon server.
+    /// It requires an [`OperationsForLiquidityPoolRequest`] to specify the liquidity pool ID and optional query parameters.
+    ///
+    /// # Arguments
+    /// * `request` - A reference to an [`OperationsForLiquidityPoolRequest`] instance, containing the liquidity pool ID
+    /// and optional query parameters for the operations for liquidity pool request.
+    ///
+    /// # Returns
+    ///
+    /// On successful execution, returns a `Result` containing a [`OperationResponse`], which includes
+    /// the list of all operations obtained from the Horizon server. If the request fails, it returns an error within `Result`.
+    ///
+    /// # Usage
+    /// To use this method, create an instance of [`OperationsForLiquidityPoolRequest`] and set the liquidity pool ID and any desired
+    /// filters or parameters.
+    ///
+    /// ```
+    /// # use stellar_rs::operations::prelude::*;
+    /// # use stellar_rs::models::Request;
+    /// # use stellar_rs::horizon_client::HorizonClient;
+    /// #
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
+    /// # let horizon_client = HorizonClient::new(base_url)
+    /// #    .expect("Failed to create Horizon Client");
+    /// let request = OperationsForLiquidityPoolRequest::new()
+    ///  .set_liquidity_pool_id("000000006520216af66d20d63a58534d6cbdf28ba9f2a9c1e03f8d9a756bb7d988b29bca".to_string());
+    ///
+    /// let response = horizon_client.get_operations_for_liquidity_pool(&request).await;
+    ///
+    /// // Access the operations
+    /// if let Ok(operations_for_liquidity_pool_response) = response {
+    ///  for operation in operations_for_liquidity_pool_response.embedded().records() {
+    ///
+    ///   println!("Operation ID: {}", operation.id());
+    /// // Further processing...
+    /// }
+    /// }
+    /// # Ok({})
+    /// # }
+    /// ```
+    ///
+    pub async fn get_operations_for_liquidity_pool(
+        &self,
+        request: &OperationsForLiquidityPoolRequest,
+    ) -> Result<OperationResponse, String> {
+        self.get::<OperationResponse>(request).await
+    }
+    
+    /// Retrieves a list of all operations for a specific transaction from the Horizon server.
+    ///
+    /// This asynchronous method fetches a list of all operations for a specific transaction from the Horizon server.
+    /// It requires an [`OperationsForTransactionRequest`] to specify the transaction hash and optional query parameters.
+    ///
+    /// # Arguments
+    /// * `request` - A reference to an [`OperationsForTransactionRequest`] instance, containing the transaction hash
+    /// and optional query parameters for the operations for transaction request.
+    ///
+    /// # Returns
+    ///
+    /// On successful execution, returns a `Result` containing a [`OperationResponse`], which includes
+    /// the list of all operations obtained from the Horizon server. If the request fails, it returns an error within `Result`.
+    ///
+    /// # Usage
+    /// To use this method, create an instance of [`OperationsForTransactionRequest`] and set the transaction hash and any desired
+    /// filters or parameters.
+    ///
+    /// ```
+    /// # use stellar_rs::operations::prelude::*;
+    /// # use stellar_rs::models::Request;
+    /// # use stellar_rs::horizon_client::HorizonClient;
+    /// #
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
+    /// # let horizon_client = HorizonClient::new(base_url)
+    /// #    .expect("Failed to create Horizon Client");
+    /// let request = OperationsForTransactionRequest::new()
+    ///  .set_transaction_hash("b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020".to_string());
+    ///
+    /// let response = horizon_client.get_operations_for_transaction(&request).await;
+    ///
+    /// // Access the operations
+    /// if let Ok(operations_for_transaction_response) = response {
+    ///  for operation in operations_for_transaction_response.embedded().records() {
+    ///   println!("Operation ID: {}", operation.id());
+    /// // Further processing...
+    /// }
+    /// }
+    /// # Ok({})
+    /// # }
+    /// ```
+    ///
+    pub async fn get_operations_for_transaction(
+        &self,
+        request: &OperationsForTransactionRequest,
+    ) -> Result<OperationResponse, String> {
+        self.get::<OperationResponse>(request).await
+    }
+    
     /// Retrieves a list of order book details from the Horizon server.
     ///
     /// This asynchronous method fetches a list of order book details from the Horizon server.
@@ -1390,56 +1535,6 @@ impl HorizonClient {
         self.get::<AllTradesResponse>(request).await
     }
 
-    /// Retrieves a list of all operations for a specific liquidity pool from the Horizon server.
-    ///
-    /// This asynchronous method fetches a list of all operations for a specific liquidity pool from the Horizon server.
-    /// It requires an [`OperationsForLiquidityPoolRequest`] to specify the liquidity pool ID and optional query parameters.
-    ///
-    /// # Arguments
-    /// * `request` - A reference to an [`OperationsForLiquidityPoolRequest`] instance, containing the liquidity pool ID
-    /// and optional query parameters for the operations for liquidity pool request.
-    ///
-    /// # Returns
-    ///
-    /// On successful execution, returns a `Result` containing a [`OperationResponse`], which includes
-    /// the list of all operations obtained from the Horizon server. If the request fails, it returns an error within `Result`.
-    ///
-    /// # Usage
-    /// To use this method, create an instance of [`OperationsForLiquidityPoolRequest`] and set the liquidity pool ID and any desired
-    /// filters or parameters.
-    ///
-    /// ```
-    /// # use stellar_rs::operations::prelude::*;
-    /// # use stellar_rs::models::Request;
-    /// # use stellar_rs::horizon_client::HorizonClient;
-    /// #
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
-    /// # let horizon_client = HorizonClient::new(base_url)
-    /// #    .expect("Failed to create Horizon Client");
-    /// let request = OperationsForLiquidityPoolRequest::new()
-    ///  .set_liquidity_pool_id("000000006520216af66d20d63a58534d6cbdf28ba9f2a9c1e03f8d9a756bb7d988b29bca".to_string());
-    ///
-    /// let response = horizon_client.get_operations_for_liquidity_pool(&request).await;
-    ///
-    /// // Access the operations
-    /// if let Ok(operations_for_liquidity_pool_response) = response {
-    ///  for operation in operations_for_liquidity_pool_response.embedded().records() {
-    ///
-    ///   println!("Operation ID: {}", operation.id());
-    /// // Further processing...
-    /// }
-    /// }
-    /// # Ok({})
-    /// # }
-    /// ```
-    ///
-    pub async fn get_operations_for_liquidity_pool(
-        &self,
-        request: &OperationsForLiquidityPoolRequest,
-    ) -> Result<OperationResponse, String> {
-        self.get::<OperationResponse>(request).await
-    }
     /// Sends a GET request to the Horizon server and retrieves a specified response type.
     ///
     /// This internal asynchronous method is designed to handle various GET requests to the

--- a/stellar_rust_sdk/src/operations/mod.rs
+++ b/stellar_rust_sdk/src/operations/mod.rs
@@ -1,36 +1,128 @@
+/// Provides the `AllOperationsRequest`.
+///
+/// # Usage
+/// This module provides the `AllOperationsRequest` struct, specifically designed for
+/// constructing requests to query information about all operations from the Horizon
+/// server. It is tailored for use with the [`HorizonClient::get_all_operations`](crate::horizon_client::HorizonClient::get_all_operations)
+/// method.
+///
 pub mod all_operations_request;
+
+/// Provides the `OperationsForAccountRequest`.
+///
+/// # Usage
+/// This module provides the `OperationsForAccountRequest` struct, specifically designed for
+/// constructing requests to query information about all operations for a given account from the Horizon
+/// server. It is tailored for use with the [`HorizonClient::get_operations_for_account`](crate::horizon_client::HorizonClient::get_operations_for_account)
+/// method.
+///
 pub mod operations_for_account_request;
+
+/// Provides the `OperationsForLedgerRequest`.
+///
+/// # Usage
+/// This module provides the `OperationsForLedgerRequest` struct, specifically designed for
+/// constructing requests to query information about all operations for a given ledger from the Horizon
+/// server. It is tailored for use with the [`HorizonClient::get_operations_for_ledger`](crate::horizon_client::HorizonClient::get_operations_for_ledger)
+/// method.
+///
 pub mod operations_for_ledger_request;
+
+/// Provides the `OperationsForLiquidityPoolRequest`.
+///
+/// # Usage
+/// This module provides the `OperationsForLiquidityPoolRequest` struct, specifically designed for
+/// constructing requests to query information about all operations for a given liquidity pool from the Horizon
+/// server. It is tailored for use with the [`HorizonClient::get_operations_for_liquidity_pool`](crate::horizon_client::HorizonClient::get_operations_for_liquidity_pool)
+/// method.
+///
 pub mod operations_for_liquidity_pool_request;
+
+/// Provides the `OperationsForTransactionRequest`.
+///
+/// # Usage
+/// This module provides the `OperationsForTransactionRequest` struct, specifically designed for
+/// constructing requests to query information about all operations for a given transaction from the Horizon
+/// server. It is tailored for use with the [`HorizonClient::get_operations_for_transaction`](crate::horizon_client::HorizonClient::get_operations_for_transaction)
+/// method.
+///
 pub mod operations_for_transaction_request;
+
+/// Provides the responses.
+///
+/// This module defines structures representing the response from the Horizon API when querying
+/// for operations. The structures are designed to deserialize the JSON response into Rust
+/// objects, enabling straightforward access to various details of a single transaction.
+///
+/// # Usage
+/// These structures are equipped with serialization capabilities to handle the JSON data from the
+/// Horizon server and with getter methods for easy field access.
 pub mod response;
+
+/// Provides the `SingleOperationRequest`.
+///
+/// # Usage
+/// This module provides the `SingleOperationRequest` struct, specifically designed for
+/// constructing requests to query information about a single operation from the Horizon
+/// server. It is tailored for use with the [`HorizonClient::get_single_operation`](crate::horizon_client::HorizonClient::get_single_operation)
+/// method.
+///
 pub mod single_operation_request;
 
+/// The base path for operation-related endpoints in the Horizon API.
+///
+/// # Usage
+/// This variable is intended to be used internally by the request-building logic
+/// to ensure consistent and accurate path construction for transaction-related API calls.
 static OPERATIONS_PATH: &str = "operations";
 
+/// The `prelude` module of the `operations` module.
+///
+/// # Usage
+/// This module serves as a convenience for users of the Horizon Rust SDK, allowing for easy and
+/// ergonomic import of the most commonly used items across various modules. It re-exports
+/// key structs and traits from the sibling modules, simplifying access to these components
+/// when using the library.
+///
+/// By importing the contents of `prelude`, users can conveniently access the primary
+/// functionalities of the transaction-related modules without needing to import each item
+/// individually.
+///
+/// # Contents
+///
+/// The `prelude` includes the following re-exports:
+///
+/// * From `single_operation_request`: All items (e.g. `SingleOperationRequest`).
+/// * From `all_operations_request`: All items (e.g. `AllOperationsRequest`).
+/// * From `operations_for_account_request`: All items (e.g. `OperationsForAccountRequest`).
+/// * From `operations_for_ledger_request`: All items (e.g. `OperationsForLedgerRequest`).
+/// * From `operations_for_liquidity_pool_request`: All items (e.g. `OperationsForLiquidityPoolRequest`).
+/// * From `operations_for_transaction_request`: All items (e.g. `OperationsForTransactionRequest`).
+/// * From `response`: All items (e.g. `OperationResponse`, `Operation`, etc.).
+///
+/// # Example
+/// ```
+/// # use crate::stellar_rs::models::*;
+/// // Import the contents of the operations prelude
+/// use stellar_rs::operations::prelude::*;
+///
+/// // Now you can directly use AllOperationsRequest, OperationResponse, etc.
+/// let all_operations_request = AllOperationsRequest::new();
+/// ```
 pub mod prelude {
     pub use super::all_operations_request::*;
     pub use super::operations_for_account_request::*;
     pub use super::operations_for_ledger_request::*;
     pub use super::operations_for_liquidity_pool_request::*;
-    //pub use super::operations_for_transaction_request::*;
+    pub use super::operations_for_transaction_request::*;
     pub use super::response::*;
     pub use super::single_operation_request::*;
 }
 
 #[cfg(test)]
 pub mod tests {
-    use crate::{
-        horizon_client,
-        operations::{
-            operations_for_account_request::OperationsForAccountRequest,
-            prelude::{
-                AllOperationsRequest, OperationsForLedgerRequest, OperationsForLiquidityPoolRequest,
-            },
-            response::{Operation, OperationResponse},
-            single_operation_request::SingleOperationRequest,
-        }, Paginatable,
-    };
+    use super::prelude::*;
+    use crate::{horizon_client::HorizonClient, Paginatable};
 
     #[tokio::test]
     async fn test_get_all_operations() {
@@ -48,7 +140,7 @@ pub mod tests {
         const ACCOUNT: &str = "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR";
 
         let horizon_client =
-            horizon_client::HorizonClient::new("https://horizon-testnet.stellar.org".to_string())
+            HorizonClient::new("https://horizon-testnet.stellar.org".to_string())
                 .unwrap();
 
         let all_operations_request = AllOperationsRequest::new().set_limit(2).unwrap();
@@ -94,7 +186,7 @@ pub mod tests {
         const ACCOUNT: &str = "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR";
 
         let horizon_client =
-            horizon_client::HorizonClient::new("https://horizon-testnet.stellar.org".to_string())
+            HorizonClient::new("https://horizon-testnet.stellar.org".to_string())
                 .unwrap();
 
         let single_operation_request =
@@ -138,7 +230,7 @@ pub mod tests {
         const ACCOUNT: &str = "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR";
 
         let horizon_client =
-            horizon_client::HorizonClient::new("https://horizon-testnet.stellar.org".to_string())
+            HorizonClient::new("https://horizon-testnet.stellar.org".to_string())
                 .unwrap();
 
         let operations_for_account_request = OperationsForAccountRequest::new()
@@ -149,7 +241,7 @@ pub mod tests {
             .unwrap();
 
         let operation_for_account_response = horizon_client
-            .get_operation_for_account(&operations_for_account_request)
+            .get_operations_for_account(&operations_for_account_request)
             .await;
 
         assert!(operation_for_account_response.is_ok());
@@ -198,7 +290,7 @@ pub mod tests {
         const ACCOUNT: &str = "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR";
 
         let horizon_client =
-            horizon_client::HorizonClient::new("https://horizon-testnet.stellar.org".to_string())
+            HorizonClient::new("https://horizon-testnet.stellar.org".to_string())
                 .unwrap();
 
         let operations_for_ledger_request = OperationsForLedgerRequest::new().set_limit(2).unwrap();
@@ -253,7 +345,7 @@ pub mod tests {
         const ACCOUNT: &str = "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR";
 
         let horizon_client =
-            horizon_client::HorizonClient::new("https://horizon-testnet.stellar.org".to_string())
+            HorizonClient::new("https://horizon-testnet.stellar.org".to_string())
                 .unwrap();
 
         let operations_for_liquidity_pool_request = OperationsForLiquidityPoolRequest::new()
@@ -262,6 +354,70 @@ pub mod tests {
 
         let operation_for_liquidity_pool_response = horizon_client
             .get_operations_for_liquidity_pool(&operations_for_liquidity_pool_request)
+            .await;
+
+        assert!(operation_for_liquidity_pool_response.is_ok());
+
+        let binding = operation_for_liquidity_pool_response.unwrap();
+        let operation_for_liquidity_pool_response = &binding.embedded().records()[0];
+
+        assert_eq!(operation_for_liquidity_pool_response.id(), ID);
+        assert_eq!(
+            operation_for_liquidity_pool_response.paging_token(),
+            PAGING_TOKEN
+        );
+        assert_eq!(
+            operation_for_liquidity_pool_response.transaction_successful(),
+            &TRANSACTION_SUCCESFULL
+        );
+        assert_eq!(
+            operation_for_liquidity_pool_response.source_account(),
+            SOURCE_ACCOUNT
+        );
+        assert_eq!(operation_for_liquidity_pool_response.type_field(), TYPE);
+        assert_eq!(operation_for_liquidity_pool_response.type_i(), &TYPE_I);
+        assert_eq!(
+            operation_for_liquidity_pool_response.created_at(),
+            CREATED_AT
+        );
+        assert_eq!(
+            operation_for_liquidity_pool_response.transaction_hash(),
+            TRANSACTION_HASH
+        );
+        assert_eq!(
+            operation_for_liquidity_pool_response.starting_balance(),
+            STARTING_BALANCE
+        );
+        assert_eq!(operation_for_liquidity_pool_response.funder(), FUNDER);
+        assert_eq!(operation_for_liquidity_pool_response.account(), ACCOUNT);
+    }
+
+    #[tokio::test]
+    async fn test_get_operations_for_transaction() {
+        const REQUEST_TRANSACTION_HASH: &str = "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
+        const ID: &str = "2314987376641";
+        const PAGING_TOKEN: &str = "2314987376641";
+        const TRANSACTION_SUCCESFULL: bool = true;
+        const SOURCE_ACCOUNT: &str = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
+        const TYPE: &str = "create_account";
+        const TYPE_I: i64 = 0;
+        const CREATED_AT: &str = "2024-06-11T21:36:12Z";
+        const TRANSACTION_HASH: &str =
+            "b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
+        const STARTING_BALANCE: &str = "10000000000.0000000";
+        const FUNDER: &str = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
+        const ACCOUNT: &str = "GAIH3ULLFQ4DGSECF2AR555KZ4KNDGEKN4AFI4SU2M7B43MGK3QJZNSR";
+
+        let horizon_client = HorizonClient::new("https://horizon-testnet.stellar.org".to_string())
+                .unwrap();
+
+        let operations_for_transaction_request = OperationsForTransactionRequest::new()
+            .set_transaction_hash(REQUEST_TRANSACTION_HASH.to_string())
+            .set_limit(2)
+            .unwrap();
+
+        let operation_for_liquidity_pool_response = horizon_client
+            .get_operations_for_transaction(&operations_for_transaction_request)
             .await;
 
         assert!(operation_for_liquidity_pool_response.is_ok());

--- a/stellar_rust_sdk/src/operations/operations_for_transaction_request.rs
+++ b/stellar_rust_sdk/src/operations/operations_for_transaction_request.rs
@@ -1,1 +1,86 @@
+use stellar_rust_sdk_derive::Pagination;
+use crate::Paginatable;
 
+use crate::{
+    models::{Order, Request},
+    BuildQueryParametersExt,
+};
+
+#[derive(Default, Pagination)]
+pub struct OperationsForTransactionRequest {
+    /// The hash of the transaction. Optional.
+    transaction_hash: Option<String>,
+    /// A number that points to a specific location in a collection of responses and is pulled
+    /// from the paging_token value of a record.
+    cursor: Option<u32>,
+    /// The maximum number of records returned. The limit can range from 1 to 200 - an upper limit
+    /// that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it
+    /// defaults to 10.
+    limit: Option<u8>,
+    /// A designation of the [`Order`] in which records should appear. Options include [`Order::Asc`] (ascending)
+    /// or [`Order::Desc`] (descending). If this argument isn’t set, it defaults to asc.
+    order: Option<Order>,
+}
+
+impl OperationsForTransactionRequest {
+    pub fn new() -> Self {
+        OperationsForTransactionRequest::default()
+    }
+
+    /// Sets the transaction hash for which to retrieve operations.
+    ///
+    /// # Arguments
+    /// * `transaction_hash` - A `String` representing the transaction hash.
+    ///
+    pub fn set_transaction_hash(self, transaction_hash: String) -> OperationsForTransactionRequest {
+        OperationsForTransactionRequest {
+            transaction_hash: Some(transaction_hash),
+            ..self
+        }
+    }
+}
+
+impl Request for OperationsForTransactionRequest {
+    fn get_query_parameters(&self) -> String {
+        vec![
+            self.cursor.as_ref().map(|c| format!("cursor={}", c)),
+            self.limit.as_ref().map(|l| format!("limit={}", l)),
+            self.order.as_ref().map(|o| format!("order={}", o)),
+        ]
+        .build_query_parameters()
+    }
+    fn build_url(&self, base_url: &str) -> String {
+        let transaction_hash = &self.transaction_hash.as_ref().unwrap();
+        use crate::transactions::TRANSACTIONS_PATH;
+        format!(
+            "{}/{}/{}/{}{}",
+            base_url,
+            TRANSACTIONS_PATH,
+            transaction_hash,
+            super::OPERATIONS_PATH,
+            self.get_query_parameters(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::Order;
+
+    #[test]
+    fn test_operations_for_transaction_request() {
+        let request = OperationsForTransactionRequest::new()
+            .set_cursor(1)
+            .unwrap()
+            .set_limit(10)
+            .unwrap()
+            .set_order(Order::Desc)
+            .unwrap();
+
+        assert_eq!(
+            request.get_query_parameters(),
+            "?cursor=1&limit=10&order=desc"
+        );
+    }
+}

--- a/stellar_rust_sdk/src/operations/operations_for_transaction_request.rs
+++ b/stellar_rust_sdk/src/operations/operations_for_transaction_request.rs
@@ -49,6 +49,7 @@ impl Request for OperationsForTransactionRequest {
         ]
         .build_query_parameters()
     }
+
     fn build_url(&self, base_url: &str) -> String {
         let transaction_hash = &self.transaction_hash.as_ref().unwrap();
         use crate::transactions::TRANSACTIONS_PATH;

--- a/stellar_rust_sdk/src/transactions/mod.rs
+++ b/stellar_rust_sdk/src/transactions/mod.rs
@@ -66,7 +66,7 @@ pub mod response;
 /// # Usage
 /// This variable is intended to be used internally by the request-building logic
 /// to ensure consistent and accurate path construction for transaction-related API calls.
-static TRANSACTIONS_PATH: &str = "transactions";
+pub(crate) static TRANSACTIONS_PATH: &str = "transactions";
 
 /// The `prelude` module of the `transactions` module.
 ///


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes #79 and #65.
- Adds the _Operations for Transaction_ request to the _Operations_ endpoint group. 
- Fixes typo in horizon client method name (`get_operations_for_account`)
- Adds missing documentation to endpoint group
- Applies cherry-picked commit for testnet updates

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current main
