### PR TITLE
Add pagination functionality for 'Offers for Account'

### DIFF
--- a/stellar_rust_sdk/src/offers/offers_for_account_request.rs
+++ b/stellar_rust_sdk/src/offers/offers_for_account_request.rs
@@ -1,4 +1,6 @@
 use crate::models::*;
+use stellar_rust_sdk_derive::Pagination;
+use crate::Paginatable;
 
 /// Represents the ID of an account for which the offers are to be retrieved.
 #[derive(Default, Clone)]
@@ -9,9 +11,19 @@ pub struct OfferAccountId(String);
 pub struct NoOfferAccountId;
 #[derive(Default)]
 
+#[derive(Pagination)]
 pub struct OffersForAccountRequest<I> {
     /// The ID of the account for which the offers are to be retrieved.
     account_id: I,
+    /// A pointer to a specific location in a collection of responses, derived from the
+    /// `paging_token` value of a record. Used for pagination control in the API response.
+    cursor: Option<u32>,
+    /// Specifies the maximum number of records to be returned in a single response.
+    /// The range for this parameter is from 1 to 200. The default value is set to 10.
+    limit: Option<u8>,
+    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
+    /// and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
+    order: Option<Order>,
 }
 
 impl OffersForAccountRequest<NoOfferAccountId> {
@@ -29,7 +41,10 @@ impl OffersForAccountRequest<NoOfferAccountId> {
         }
 
         Ok(OffersForAccountRequest {
-            account_id: OfferAccountId(account_id,)
+            account_id: OfferAccountId(account_id,),
+            cursor: self.cursor,
+            limit: self.limit,
+            order: self.order,
         })
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes #93. Adds pagination functionality to the _Offers for Account_ request. Applies testnet updates using a cherry-picked commit.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current main
