### PR TITLE
Use IncludeFailed enum in 'All Transactions' request

### DIFF
--- a/stellar_rust_sdk/src/horizon_client.rs
+++ b/stellar_rust_sdk/src/horizon_client.rs
@@ -1661,7 +1661,7 @@ impl HorizonClient {
     ///
     /// ```
     /// # use stellar_rs::transactions::prelude::*;
-    /// # use stellar_rs::models::Request;
+    /// # use stellar_rs::models::{Request, IncludeFailed};
     /// # use stellar_rs::horizon_client::HorizonClient;
     /// # use stellar_rust_sdk_derive::Pagination;
     /// # use stellar_rs::Paginatable;
@@ -1671,7 +1671,7 @@ impl HorizonClient {
     /// # let horizon_client = HorizonClient::new(base_url)
     /// #    .expect("Failed to create Horizon Client");
     /// let request = AllTransactionsRequest::new()
-    ///   .set_include_failed(true).unwrap();
+    ///   .set_include_failed(IncludeFailed::True).unwrap();
     ///
     /// let response = horizon_client.get_all_transactions(&request).await;
     ///

--- a/stellar_rust_sdk/src/liquidity_pools/mod.rs
+++ b/stellar_rust_sdk/src/liquidity_pools/mod.rs
@@ -80,7 +80,7 @@ async fn test_get_all_liquidity_pools() {
         "4cd1f6defba237eecbc5fefe259f89ebc4b5edd49116beb5536c4034fc48d63f";
     const RSP_1_LIQUIDITY_POOL_FEE_BP: i64 = 30;
     const RSP_1_LIQUIDITY_POOL_TYPE: &str = "constant_product";
-    const RSP_1_LIQUIDITY_POOL_TOTAL_TRUSTLINES: &str = "1";
+    const RSP_1_LIQUIDITY_POOL_TOTAL_TRUSTLINES: &str = "2";
     const RSP_1_LIQUIDITY_POOL_RESERVE_ASSET_0: &str = "native";
     const RSP_1_LIQUIDITY_POOL_RESERVE_ASSET_1: &str =
         "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
@@ -94,10 +94,10 @@ async fn test_get_all_liquidity_pools() {
     const RSP_2_LIQUIDITY_POOL_TOTAL_TRUSTLINES: &str = "1";
     const RSP_2_LIQUIDITY_POOL_TOTAL_SHARES: &str = "249.0000000";
     const RSP_2_LIQUIDITY_POOL_RESERVE_ASSET_0: &str = "native";
-    const RSP_2_LIQUIDITY_POOL_RESERVE_AMOUNT_0: &str = "1249.0000000";
+    const RSP_2_LIQUIDITY_POOL_RESERVE_AMOUNT_0: &str = "2939.0000000";
     const RSP_2_LIQUIDITY_POOL_RESERVE_ASSET_1: &str =
         "FLUTTER:GCGTOQSNERFVVJ6Y7YZYDF3MTZIY63KIEFMKA26Q7YPV3AFYD2JSRNYN";
-    const RSP_2_LIQUIDITY_POOL_RESERVE_AMOUNT_1: &str = "49.7600322";
+    const RSP_2_LIQUIDITY_POOL_RESERVE_AMOUNT_1: &str = "21.1917647";
 
     const RSP_3_LIQUIDITY_POOL_ID: &str =
         "0b3c88caa5aeada296646c1810893e3b04cba0426cff8ff6a63cf6f35cc7f5b3";
@@ -109,10 +109,10 @@ async fn test_get_all_liquidity_pools() {
     const RSP_3_LIQUIDITY_POOL_TOTAL_SHARES: &str = "150.0000000";
     const RSP_3_LIQUIDITY_POOL_RESERVE_ASSET_0: &str =
         "SDK:GAGTRBIF75N7NUA37JGGJZKXIS4JJKTQERRFWTP5DN4SM4OC2T6QPMQB";
-    const RSP_3_LIQUIDITY_POOL_RESERVE_AMOUNT_0: &str = "160.0000000";
+    const RSP_3_LIQUIDITY_POOL_RESERVE_AMOUNT_0: &str = "158.0667366";
     const RSP_3_LIQUIDITY_POOL_RESERVE_ASSET_1: &str =
         "FLUTTER:GCGTOQSNERFVVJ6Y7YZYDF3MTZIY63KIEFMKA26Q7YPV3AFYD2JSRNYN";
-    const RSP_3_LIQUIDITY_POOL_RESERVE_AMOUNT_1: &str = "140.6513722";
+    const RSP_3_LIQUIDITY_POOL_RESERVE_AMOUNT_1: &str = "142.3768102";
 
     let horizon_client =
         HorizonClient::new("https://horizon-testnet.stellar.org".to_string()).unwrap();
@@ -294,12 +294,12 @@ async fn test_get_single_liquidity_pool() {
     const LIQUIDITY_POOL_TOTAL_SHARES: &str = "249.0000000";
     const LIQUIDITY_POOL_RESERVE_ASSET_0: &str =
         "native";
-    const LIQUIDITY_POOL_RESERVE_AMOUNT_0: &str = "1249.0000000";
+    const LIQUIDITY_POOL_RESERVE_AMOUNT_0: &str = "2939.0000000";
     const LIQUIDITY_POOL_RESERVE_ASSET_1: &str =
         "FLUTTER:GCGTOQSNERFVVJ6Y7YZYDF3MTZIY63KIEFMKA26Q7YPV3AFYD2JSRNYN";
-    const LIQUIDITY_POOL_RESERVE_AMOUNT_1: &str = "49.7600322";
-    const LIQUIDITY_POOL_LAST_MODIFIED_LEDGER: i64 = 716080;
-    const LIQUIDITY_POOL_LAST_MODIFIED_TIME: &str = "2024-07-25T11:09:01Z";
+    const LIQUIDITY_POOL_RESERVE_AMOUNT_1: &str = "21.1917647";
+    const LIQUIDITY_POOL_LAST_MODIFIED_LEDGER: i64 = 1025861;
+    const LIQUIDITY_POOL_LAST_MODIFIED_TIME: &str = "2024-08-13T07:20:55Z";
 
     let horizon_client =
         HorizonClient::new("https://horizon-testnet.stellar.org".to_string()).unwrap();

--- a/stellar_rust_sdk/src/offers/mod.rs
+++ b/stellar_rust_sdk/src/offers/mod.rs
@@ -85,26 +85,26 @@ pub mod test {
     use super::prelude::*;
     use crate::{horizon_client::HorizonClient, models::*, Paginatable};
 
-    const LINK_SELF: &str = "https://horizon-testnet.stellar.org/offers/7";
-    const LINK_OFFER_MAKER: &str =  "https://horizon-testnet.stellar.org/accounts/GCXRNJ23TEHRNXQJEYXGQ3IYGVAWWY6Z2VOOWPP6STTYQCKXIRTNCN3E";
-    const OFFER_ID: &str = "7";
-    const PAGING_TOKEN: &str = "7";
-    const SELLER: &str = "GCXRNJ23TEHRNXQJEYXGQ3IYGVAWWY6Z2VOOWPP6STTYQCKXIRTNCN3E";
-    const SELLING_ASSET_TYPE: &str = "credit_alphanum12";
-    const SELLING_ASSET_CODE: &str = "MBAUDD";
-    const SELLING_ASSET_ISSUER: &str = "GD2YNRNSJ3EOFJAYGLKGKSIOLX2VU3UFDW3YFNOYMAHB26AEHSZBJU4U";
-    const BUYING_ASSET_TYPE: &str = "credit_alphanum12";
-    const BUYING_ASSET_CODE: &str = "TMB001128";
-    const BUYING_ASSET_ISSUER: &str = "GBH2HB7DZN7PRJP5RED2SQZAKSYYBH43PQCQH3NOYT2Y2KLODQZM3M2F";
-    const AMOUNT: &str = "41011.9400000";
-    const PRICE_R_N: &u32 = &50;
-    const PRICE_R_D: &u32 = &467;
-    const PRICE: &str = "0.1070664";
-    const LAST_MODIFIED_LEDGER: &u32 = &4739;
-    const LAST_MODIFIED_TIME: &str = "2024-06-12T03:45:47Z";
-
     #[tokio::test]
     async fn test_get_single_offer() {
+        const LINK_SELF: &str = "https://horizon-testnet.stellar.org/offers/27493";
+        const LINK_OFFER_MAKER: &str =  "https://horizon-testnet.stellar.org/accounts/GCXRNJ23TEHRNXQJEYXGQ3IYGVAWWY6Z2VOOWPP6STTYQCKXIRTNCN3E";
+        const OFFER_ID: &str = "27493";
+        const PAGING_TOKEN: &str = "27493";
+        const SELLER: &str = "GCXRNJ23TEHRNXQJEYXGQ3IYGVAWWY6Z2VOOWPP6STTYQCKXIRTNCN3E";
+        const SELLING_ASSET_TYPE: &str = "credit_alphanum12";
+        const SELLING_ASSET_CODE: &str = "MBAUDD";
+        const SELLING_ASSET_ISSUER: &str = "GD2YNRNSJ3EOFJAYGLKGKSIOLX2VU3UFDW3YFNOYMAHB26AEHSZBJU4U";
+        const BUYING_ASSET_TYPE: &str = "credit_alphanum12";
+        const BUYING_ASSET_CODE: &str = "TMB001128";
+        const BUYING_ASSET_ISSUER: &str = "GBH2HB7DZN7PRJP5RED2SQZAKSYYBH43PQCQH3NOYT2Y2KLODQZM3M2F";
+        const AMOUNT: &str = "20081.0000000";
+        const PRICE_R_N: &u32 = &50;
+        const PRICE_R_D: &u32 = &467;
+        const PRICE: &str = "0.1070664";
+        const LAST_MODIFIED_LEDGER: &u32 = &845805;
+        const LAST_MODIFIED_TIME: &str = "2024-08-02T08:29:11Z";
+
         let horizon_client =
             HorizonClient::new("https://horizon-testnet.stellar.org"
             .to_string())
@@ -142,6 +142,22 @@ pub mod test {
 
     #[tokio::test]
     async fn test_get_all_offers() {
+        const LINK_SELF: &str = "https://horizon-testnet.stellar.org/offers/99";
+        const LINK_OFFER_MAKER: &str =  "https://horizon-testnet.stellar.org/accounts/GBJJ5OCBXNZWHSJJ4YQ6ECK24MBJSZMLEMINHKGGEWUA5RU2EDMPN6MS";
+        const OFFER_ID: &str = "99";
+        const PAGING_TOKEN: &str = "99";
+        const SELLER: &str = "GBJJ5OCBXNZWHSJJ4YQ6ECK24MBJSZMLEMINHKGGEWUA5RU2EDMPN6MS";
+        const SELLING_ASSET_TYPE: &str = "native";
+        const BUYING_ASSET_TYPE: &str = "credit_alphanum12";
+        const BUYING_ASSET_CODE: &str = "NewDollar";
+        const BUYING_ASSET_ISSUER: &str = "GBAKINTNEGR7PO6Z6XW2S5ITT5VARNW6DZ5K4OYSLFNEA2CSMUM2UEF4";
+        const AMOUNT: &str = "10.0000000";
+        const PRICE_R_N: &u32 = &1;
+        const PRICE_R_D: &u32 = &1;
+        const PRICE: &str = "1.0000000";
+        const LAST_MODIFIED_LEDGER: &u32 = &5858;
+        const LAST_MODIFIED_TIME: &str = "2024-06-12T05:23:41Z";
+    
         let horizon_client =
             HorizonClient::new("https://horizon-testnet.stellar.org"
             .to_string())
@@ -164,8 +180,6 @@ pub mod test {
         assert_eq!(record.paging_token(), PAGING_TOKEN);
         assert_eq!(record.seller(), SELLER);
         assert_eq!(record.selling().asset_type(), SELLING_ASSET_TYPE);
-        assert_eq!(record.selling().asset_code().as_ref().unwrap(), SELLING_ASSET_CODE);
-        assert_eq!(record.selling().asset_issuer().as_ref().unwrap(), SELLING_ASSET_ISSUER);
         assert_eq!(record.buying().asset_type(), BUYING_ASSET_TYPE);
         assert_eq!(record.buying().asset_code().as_ref().unwrap(), BUYING_ASSET_CODE);
         assert_eq!(record.buying().asset_issuer().as_ref().unwrap(), BUYING_ASSET_ISSUER);
@@ -190,12 +204,12 @@ pub mod test {
         const BUYING_ASSET_TYPE: &str = "credit_alphanum12";
         const BUYING_ASSET_CODE: &str = "EURCAllow";
         const BUYING_ASSET_ISSUER: &str = "GA6HVGLFUF3BHHGR5CMYXIVZ3RYVUH5EUYAOAY4T3OKI5OQVIWVRK24R";
-        const AMOUNT: &str = "922307928093.4475807";
+        const AMOUNT: &str = "922192119415.1975807";
         const PRICE_R_N: &u32 = &1;
         const PRICE_R_D: &u32 = &1;
         const PRICE: &str = "1.0000000";
-        const LAST_MODIFIED_LEDGER: &u32 = &286496;
-        const LAST_MODIFIED_TIME: &str = "2024-06-29T07:08:23Z";
+        const LAST_MODIFIED_LEDGER: &u32 = &923809;
+        const LAST_MODIFIED_TIME: &str = "2024-08-07T02:21:13Z";
     
         let horizon_client =
             HorizonClient::new("https://horizon-testnet.stellar.org"
@@ -238,6 +252,24 @@ pub mod test {
     #[tokio::test]
     async fn test_get_offers_for_account() {
         const ACCOUNT_ID: &str = "GCXRNJ23TEHRNXQJEYXGQ3IYGVAWWY6Z2VOOWPP6STTYQCKXIRTNCN3E";
+        const LINK_SELF: &str = "https://horizon-testnet.stellar.org/offers/27493";
+        const LINK_OFFER_MAKER: &str =  "https://horizon-testnet.stellar.org/accounts/GCXRNJ23TEHRNXQJEYXGQ3IYGVAWWY6Z2VOOWPP6STTYQCKXIRTNCN3E";
+        const OFFER_ID: &str = "27493";
+        const PAGING_TOKEN: &str = "27493";
+        const SELLER: &str = "GCXRNJ23TEHRNXQJEYXGQ3IYGVAWWY6Z2VOOWPP6STTYQCKXIRTNCN3E";
+        const SELLING_ASSET_TYPE: &str = "credit_alphanum12";
+        const SELLING_ASSET_CODE: &str = "MBAUDD";
+        const SELLING_ASSET_ISSUER: &str = "GD2YNRNSJ3EOFJAYGLKGKSIOLX2VU3UFDW3YFNOYMAHB26AEHSZBJU4U";
+        const BUYING_ASSET_TYPE: &str = "credit_alphanum12";
+        const BUYING_ASSET_CODE: &str = "TMB001128";
+        const BUYING_ASSET_ISSUER: &str = "GBH2HB7DZN7PRJP5RED2SQZAKSYYBH43PQCQH3NOYT2Y2KLODQZM3M2F";
+        const AMOUNT: &str = "20081.0000000";
+        const PRICE_R_N: &u32 = &50;
+        const PRICE_R_D: &u32 = &467;
+        const PRICE: &str = "0.1070664";
+        const LAST_MODIFIED_LEDGER: &u32 = &845805;
+        const LAST_MODIFIED_TIME: &str = "2024-08-02T08:29:11Z";
+    
         let horizon_client =
             HorizonClient::new("https://horizon-testnet.stellar.org"
             .to_string())

--- a/stellar_rust_sdk/src/order_book/mod.rs
+++ b/stellar_rust_sdk/src/order_book/mod.rs
@@ -14,9 +14,9 @@ pub mod tests {
         use crate::horizon_client;
         use crate::order_book::prelude::{Asset, AssetType, DetailsRequest};
 
-        const BIDS_N: &u32 = &3;
-        const BIDS_D: &u32 = &2;
-        const BIDS_PRICE: &str = "1.5000000";
+        const BIDS_N: &u32 = &1;
+        const BIDS_D: &u32 = &5;
+        const BIDS_PRICE: &str = "0.2000000";
         const ASKS_N: &u32 = &5;
         const ASKS_D: &u32 = &1;
         const ASKS_PRICE: &str = "5.0000000";

--- a/stellar_rust_sdk/src/trades/mod.rs
+++ b/stellar_rust_sdk/src/trades/mod.rs
@@ -145,8 +145,8 @@ pub mod test {
         assert_eq!(response.base_asset_type().as_ref().unwrap(), BASE_ASSET_TYPE);
         assert_eq!(response.base_asset_code().as_ref().unwrap(), BASE_ASSET_CODE);
         assert_eq!(response.base_asset_issuer().as_ref().unwrap(), BASE_ASSET_ISSUER);
-        assert_eq!(response.counter_offer_id(), COUNTER_OFFER_ID);
-        assert_eq!(response.counter_account(), COUNTER_ACCOUNT);
+        assert_eq!(response.counter_offer_id().as_ref().unwrap(), COUNTER_OFFER_ID);
+        assert_eq!(response.counter_account().as_ref().unwrap(), COUNTER_ACCOUNT);
         assert_eq!(response.counter_amount(), COUNTER_AMOUNT);
         assert_eq!(response.counter_asset_type().as_ref().unwrap(), COUNTER_ASSET_TYPE);
         assert_eq!(response.counter_asset_code().as_ref().unwrap(), COUNTER_ASSET_CODE);
@@ -211,8 +211,8 @@ pub mod test {
         assert_eq!(response.base_asset_type().as_ref().unwrap(), BASE_ASSET_TYPE);
         assert_eq!(response.base_asset_code().as_ref().unwrap(), BASE_ASSET_CODE);
         assert_eq!(response.base_asset_issuer().as_ref().unwrap(), BASE_ASSET_ISSUER);
-        assert_eq!(response.counter_offer_id(), COUNTER_OFFER_ID);
-        assert_eq!(response.counter_account(), COUNTER_ACCOUNT);
+        assert_eq!(response.counter_offer_id().as_ref().unwrap(), COUNTER_OFFER_ID);
+        assert_eq!(response.counter_account().as_ref().unwrap(), COUNTER_ACCOUNT);
         assert_eq!(response.counter_amount(), COUNTER_AMOUNT);
         assert_eq!(response.counter_asset_type().as_ref().unwrap(), COUNTER_ASSET_TYPE);
         assert_eq!(response.counter_asset_code().as_ref().unwrap(), COUNTER_ASSET_CODE);
@@ -260,7 +260,7 @@ pub mod test {
             .get_trades_for_liquidity_pool(&trades_for_liquidity_pool_request)
             .await;
 
-        assert!(trades_for_liquidity_pool_response.clone().is_ok());
+        // assert!(trades_for_liquidity_pool_response.clone().is_ok());
         let binding = trades_for_liquidity_pool_response.unwrap();
         let response = &binding.embedded().records()[0];
         assert_eq!(response.links().self_link().href().as_ref().unwrap(), LINK_SELF);
@@ -277,8 +277,8 @@ pub mod test {
         assert_eq!(response.base_asset_type().as_ref().unwrap(), BASE_ASSET_TYPE);
         assert_eq!(response.base_asset_code().as_ref().unwrap(), BASE_ASSET_CODE);
         assert_eq!(response.base_asset_issuer().as_ref().unwrap(), BASE_ASSET_ISSUER);
-        assert_eq!(response.counter_offer_id(), COUNTER_OFFER_ID);
-        assert_eq!(response.counter_account(), COUNTER_ACCOUNT);
+        assert_eq!(response.counter_offer_id().as_ref().unwrap(), COUNTER_OFFER_ID);
+        assert_eq!(response.counter_account().as_ref().unwrap(), COUNTER_ACCOUNT);
         assert_eq!(response.counter_amount(), COUNTER_AMOUNT);
         assert_eq!(response.counter_asset_type().as_ref().unwrap(), COUNTER_ASSET_TYPE);
         assert_eq!(response.counter_asset_code().as_ref().unwrap(), COUNTER_ASSET_CODE);
@@ -305,7 +305,6 @@ pub mod test {
         const BASE_ASSET_TYPE: &str = "credit_alphanum4";
         const BASE_ASSET_CODE: &str = "XETH";
         const BASE_ASSET_ISSUER: &str = "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI";
-        const COUNTER_OFFER_ID: &str = "21";
         const COUNTER_ACCOUNT: &str = "GBHRHA3KGRJBXBFER7VHI3WS5SKUXOP5TQ3YITVD7WJ2D3INGK62FZJR";
         const COUNTER_AMOUNT: &str = "1.0800000";
         const COUNTER_ASSET_TYPE: &str = "credit_alphanum4";
@@ -326,7 +325,7 @@ pub mod test {
             .get_trades_for_offer(&trades_for_offer_request)
             .await;
 
-        // assert!(trades_for_liquidity_pools_response.clone().is_ok());
+        assert!(trades_for_liquidity_pools_response.clone().is_ok());
         let binding = trades_for_liquidity_pools_response.unwrap();
         let response = &binding.embedded().records()[0];
         assert_eq!(response.links().self_link().href().as_ref().unwrap(), LINK_SELF);
@@ -343,8 +342,7 @@ pub mod test {
         assert_eq!(response.base_asset_type().as_ref().unwrap(), BASE_ASSET_TYPE);
         assert_eq!(response.base_asset_code().as_ref().unwrap(), BASE_ASSET_CODE);
         assert_eq!(response.base_asset_issuer().as_ref().unwrap(), BASE_ASSET_ISSUER);
-        assert_eq!(response.counter_offer_id(), COUNTER_OFFER_ID);
-        assert_eq!(response.counter_account(), COUNTER_ACCOUNT);
+        assert_eq!(response.counter_account().as_ref().unwrap(), COUNTER_ACCOUNT);
         assert_eq!(response.counter_amount(), COUNTER_AMOUNT);
         assert_eq!(response.counter_asset_type().as_ref().unwrap(), COUNTER_ASSET_TYPE);
         assert_eq!(response.counter_asset_code().as_ref().unwrap(), COUNTER_ASSET_CODE);

--- a/stellar_rust_sdk/src/trades/response.rs
+++ b/stellar_rust_sdk/src/trades/response.rs
@@ -88,10 +88,10 @@ pub struct TradeResponse {
     base_asset_issuer: Option<String>,
     // The counter liquidity pool ID, if this trade was executed against a liquidity pool.
     counter_liquidity_pool_id: Option<String>,
-    // The counter offer ID.
-    counter_offer_id: String,
+    // The counter offer ID. Optional.
+    counter_offer_id: Option<String>,
     // The account ID of the counter party for this trade.
-    counter_account: String,
+    counter_account: Option<String>,
     // The amount of the counter asset that was moved from `counter_account` to `base_account`.
     counter_amount: String,
     // The type for the counter asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.

--- a/stellar_rust_sdk/src/transactions/all_transactions_request.rs
+++ b/stellar_rust_sdk/src/transactions/all_transactions_request.rs
@@ -34,7 +34,7 @@ use crate::Paginatable;
 #[derive(Default, Pagination)]
 pub struct AllTransactionsRequest {
     // Indicates whether or not to include failed operations in the response.
-    include_failed: Option<bool>,
+    include_failed: Option<IncludeFailed>,
     /// A pointer to a specific location in a collection of responses, derived from the
     /// `paging_token` value of a record. Used for pagination control in the API response.
     cursor: Option<u32>,
@@ -77,7 +77,7 @@ impl AllTransactionsRequest {
     ///
     /// # Arguments
     /// * `include_failed` (bool) - when set to `true`, failed operations will be included.
-    pub fn set_include_failed(self, include_failed: bool) -> Result<AllTransactionsRequest, String> {
+    pub fn set_include_failed(self, include_failed: IncludeFailed) -> Result<AllTransactionsRequest, String> {
         Ok(AllTransactionsRequest {
             include_failed: Some(include_failed),
             ..self

--- a/stellar_rust_sdk/src/transactions/all_transactions_request.rs
+++ b/stellar_rust_sdk/src/transactions/all_transactions_request.rs
@@ -18,12 +18,12 @@ use crate::Paginatable;
 /// # Example
 /// ```
 /// use stellar_rs::transactions::all_transactions_request::AllTransactionsRequest;
-/// use stellar_rs::models::{Order};
+/// use stellar_rs::models::{Order, IncludeFailed};
 /// use stellar_rust_sdk_derive::Pagination;
 /// use stellar_rs::Paginatable;
 ///
 /// let request = AllTransactionsRequest::new()
-///     .set_include_failed(true).unwrap() // Optional flag to include failed transactions
+///     .set_include_failed(IncludeFailed::True).unwrap() // Optional flag to include failed transactions
 ///     .set_cursor(123).unwrap() // Optional cursor for pagination
 ///     .set_limit(100).unwrap() // Optional limit for response records
 ///     .set_order(Order::Desc); // Optional order of records

--- a/stellar_rust_sdk/src/transactions/mod.rs
+++ b/stellar_rust_sdk/src/transactions/mod.rs
@@ -109,6 +109,7 @@ pub mod prelude {
 #[cfg(test)]
 pub mod test {
     use super::prelude::*;
+    use crate::models::IncludeFailed;
     use crate::horizon_client::HorizonClient;
 
     const LINK_SELF: &str = "https://horizon-testnet.stellar.org/transactions/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020";
@@ -193,7 +194,7 @@ pub mod test {
             .unwrap();
 
         let all_transactions_request = AllTransactionsRequest::new()
-            .set_include_failed(true)
+            .set_include_failed(IncludeFailed::True)
             .unwrap();
 
         let all_transactions_response = horizon_client


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes  #95. Replaces the boolean in the request struct with the `IncludeFailed` enum (which is defined in `models`).
Applies testnet updates using a cherry-picked commit.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current main
