### PR TITLE
Add pagination members to struct via macro

### DIFF
--- a/stellar_rust_sdk/src/assets/all_assets_request.rs
+++ b/stellar_rust_sdk/src/assets/all_assets_request.rs
@@ -1,5 +1,5 @@
-use crate::{models::*, BuildQueryParametersExt, Paginatable};
-use stellar_rust_sdk_derive::Pagination;
+use crate::{models::*, BuildQueryParametersExt};
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents a request for listing all assets in the Stellar Horizon API.
 ///
@@ -38,27 +38,15 @@ use stellar_rust_sdk_derive::Pagination;
 ///
 /// ```
 ///
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct AllAssetsRequest {
     /// The code of the asset to filter by. This is typically the identifier
     ///   assigned to custom assets on the Stellar network.
     asset_code: Option<String>,
-
     /// The Stellar address of the issuer for the asset you want to filter by.
     ///   It is relevant for assets that are custom issued on the Stellar network.
     asset_issuer: Option<String>,
-
-    /// A pointer to a specific location in a collection of responses, derived from the
-    ///   `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-
-    /// Specifies the maximum number of records to be returned in a single response.
-    ///   The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u8>,
-
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    ///   and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
 }
 
 impl Request for AllAssetsRequest {

--- a/stellar_rust_sdk/src/assets/all_assets_request.rs
+++ b/stellar_rust_sdk/src/assets/all_assets_request.rs
@@ -18,8 +18,6 @@ use stellar_rust_sdk_derive::pagination;
 /// # use stellar_rs::assets::prelude::{AllAssetsRequest, AllAssetsResponse};
 /// # use stellar_rs::models::*;
 /// # use stellar_rs::horizon_client::HorizonClient;
-/// # use stellar_rust_sdk_derive::Pagination;
-/// # use stellar_rs::Paginatable;
 /// #
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// # let base_url = "https://horizon-testnet.stellar.org".to_string();

--- a/stellar_rust_sdk/src/assets/mod.rs
+++ b/stellar_rust_sdk/src/assets/mod.rs
@@ -76,7 +76,7 @@ pub mod prelude {
 #[cfg(test)]
 pub mod test {
     use super::prelude::*;
-    use crate::{horizon_client::HorizonClient, Paginatable};
+    use crate::{horizon_client::HorizonClient};
 
     #[tokio::test]
     async fn test_get_all_assets() {

--- a/stellar_rust_sdk/src/claimable_balances/all_claimable_balances_request.rs
+++ b/stellar_rust_sdk/src/claimable_balances/all_claimable_balances_request.rs
@@ -1,5 +1,5 @@
-use crate::{models::*, BuildQueryParametersExt, Paginatable};
-use stellar_rust_sdk_derive::Pagination;
+use crate::{models::*, BuildQueryParametersExt};
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents a request to list all claimable balances from the Stellar Horizon API.
 ///
@@ -32,7 +32,8 @@ use stellar_rust_sdk_derive::Pagination;
 /// // Use with HorizonClient::get_all_claimable_balances
 /// ```
 ///
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct AllClaimableBalancesRequest {
     /// Optional. Representing the account ID of the sponsor. When set, the response will
     ///   only include claimable balances sponsored by the specified account.
@@ -45,18 +46,6 @@ pub struct AllClaimableBalancesRequest {
     /// Optional. Represents the account ID of the claimant. If provided, the response will
     ///   include only claimable balances that are claimable by the specified account.
     claimant: Option<String>,
-
-    /// A pointer to a specific location in a collection of responses, derived from the
-    ///   `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-
-    /// Specifies the maximum number of records to be returned in a single response.
-    ///   The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u8>,
-
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    ///   and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
 }
 
 impl Request for AllClaimableBalancesRequest {

--- a/stellar_rust_sdk/src/claimable_balances/all_claimable_balances_request.rs
+++ b/stellar_rust_sdk/src/claimable_balances/all_claimable_balances_request.rs
@@ -19,7 +19,6 @@ use stellar_rust_sdk_derive::pagination;
 /// ```
 /// # use stellar_rs::claimable_balances::all_claimable_balances_request::AllClaimableBalancesRequest;
 /// # use stellar_rs::models::{Asset, Order, IssuedAsset};
-/// # use crate::stellar_rs::Paginatable;
 ///
 /// let request = AllClaimableBalancesRequest::new()
 ///     .set_sponsor("GDQJUTQYK2MQX2VGDR2FYWLIYAQIEGXTQVTFEMGH2BEWFG4BRUY4CKI7".to_string()).unwrap() // Optional sponsor filter

--- a/stellar_rust_sdk/src/claimable_balances/mod.rs
+++ b/stellar_rust_sdk/src/claimable_balances/mod.rs
@@ -96,7 +96,7 @@ pub mod prelude {
 mod tests {
     use super::parse_epoch;
     use super::prelude::*;
-    use crate::{horizon_client::HorizonClient, Paginatable};
+    use crate::{horizon_client::HorizonClient};
     use chrono::DateTime;
     use chrono::{TimeZone, Utc};
     use lazy_static::lazy_static;

--- a/stellar_rust_sdk/src/effects/all_effects_request.rs
+++ b/stellar_rust_sdk/src/effects/all_effects_request.rs
@@ -16,8 +16,6 @@ use stellar_rust_sdk_derive::pagination;
 /// ```rust
 /// # use stellar_rs::effects::all_effects_request::AllEffectsRequest;
 /// # use stellar_rs::models::*;
-/// # use stellar_rust_sdk_derive::Pagination;
-/// # use crate::stellar_rs::Paginatable;
 ///
 /// let request = AllEffectsRequest::new()
 ///     .set_cursor(1234).unwrap()

--- a/stellar_rust_sdk/src/effects/all_effects_request.rs
+++ b/stellar_rust_sdk/src/effects/all_effects_request.rs
@@ -1,5 +1,5 @@
-use crate::{models::*, BuildQueryParametersExt, Paginatable};
-use stellar_rust_sdk_derive::Pagination;
+use crate::{models::*, BuildQueryParametersExt};
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents a request to fetch effect data from the Stellar Horizon API.
 ///
@@ -27,17 +27,9 @@ use stellar_rust_sdk_derive::Pagination;
 /// // The request can now be used with a Horizon client to fetch effects.
 /// ```
 ///
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct AllEffectsRequest {
-    /// A pointer to a specific location in a collection of responses, derived from the
-    ///   `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    ///   The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    ///   and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
 }
 
 impl AllEffectsRequest {

--- a/stellar_rust_sdk/src/effects/all_effects_request.rs
+++ b/stellar_rust_sdk/src/effects/all_effects_request.rs
@@ -28,6 +28,7 @@ use stellar_rust_sdk_derive::pagination;
 #[pagination]
 #[derive(Default)]
 pub struct AllEffectsRequest {
+    // All fields are injected by the `pagination` macro.
 }
 
 impl AllEffectsRequest {

--- a/stellar_rust_sdk/src/effects/effects_for_account_request.rs
+++ b/stellar_rust_sdk/src/effects/effects_for_account_request.rs
@@ -1,9 +1,8 @@
 use crate::{
     models::{Order, Request},
     BuildQueryParametersExt,
-    Paginatable,
 };
-use stellar_rust_sdk_derive::Pagination;
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents the request to fetch effects for a specific account from the Horizon API.
 ///
@@ -37,20 +36,11 @@ use stellar_rust_sdk_derive::Pagination;
 /// // The request can now be used with a Horizon client to fetch effects.
 /// ```
 ///
-
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct EffectsForAccountRequest {
     /// The accounts public id
     account_id: Option<String>,
-    /// A pointer to a specific location in a collection of responses, derived from the
-    ///   `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    ///   The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    ///   and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
 }
 
 impl EffectsForAccountRequest {

--- a/stellar_rust_sdk/src/effects/effects_for_account_request.rs
+++ b/stellar_rust_sdk/src/effects/effects_for_account_request.rs
@@ -25,8 +25,6 @@ use stellar_rust_sdk_derive::pagination;
 /// ```rust
 /// # use stellar_rs::effects::effects_for_account_request::EffectsForAccountRequest;
 /// # use stellar_rs::models::*;
-/// # use stellar_rust_sdk_derive::Pagination;
-/// # use crate::stellar_rs::Paginatable;
 ///
 /// let request = EffectsForAccountRequest::new()
 ///     .set_cursor(1234).unwrap()

--- a/stellar_rust_sdk/src/effects/effects_for_ledger_request.rs
+++ b/stellar_rust_sdk/src/effects/effects_for_ledger_request.rs
@@ -14,8 +14,6 @@ use stellar_rust_sdk_derive::pagination;
 /// ```rust
 /// # use stellar_rs::effects::effects_for_ledger_request::EffectsForLedgerRequest;
 /// # use stellar_rs::models::Order;
-/// # use stellar_rust_sdk_derive::Pagination;
-/// # use stellar_rs::Paginatable;
 ///
 /// let mut request = EffectsForLedgerRequest::new()
 ///     .set_sequence(&1000)

--- a/stellar_rust_sdk/src/effects/effects_for_ledger_request.rs
+++ b/stellar_rust_sdk/src/effects/effects_for_ledger_request.rs
@@ -1,9 +1,8 @@
 use crate::{
     models::{Order, Request},
     BuildQueryParametersExt,
-    Paginatable,
 };
-use stellar_rust_sdk_derive::Pagination;
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents a request to fetch effects associated with a specific ledger from the Stellar Horizon API.
 ///
@@ -25,19 +24,11 @@ use stellar_rust_sdk_derive::Pagination;
 /// // The request is now ready to be used with a Horizon client to fetch effects for the specified ledger.
 /// ```
 ///
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct EffectsForLedgerRequest {
     /// The ledger's sequence number for which effects are to be retrieved.
     sequence: Option<u32>,
-    /// A pointer to a specific location in a collection of responses, derived from the
-    ///   `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    ///   The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    ///   and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
 }
 
 impl EffectsForLedgerRequest {

--- a/stellar_rust_sdk/src/effects/effects_for_liquidity_pools_request.rs
+++ b/stellar_rust_sdk/src/effects/effects_for_liquidity_pools_request.rs
@@ -23,8 +23,6 @@ use stellar_rust_sdk_derive::pagination;
 /// ```rust
 /// # use stellar_rs::effects::effects_for_liquidity_pools_request::EffectsForLiquidityPoolRequest;
 /// # use stellar_rs::models::*;
-/// # use stellar_rust_sdk_derive::Pagination;
-/// # use stellar_rs::Paginatable;
 ///
 /// let request = EffectsForLiquidityPoolRequest::new()
 ///     .set_liquidity_pool_id("01c58ab8fb283c8b083a26bf2fe06b7b6c6304c13f9d29d956cdf15a48bea72d".to_string())

--- a/stellar_rust_sdk/src/effects/effects_for_liquidity_pools_request.rs
+++ b/stellar_rust_sdk/src/effects/effects_for_liquidity_pools_request.rs
@@ -1,7 +1,6 @@
 use crate::models::{Order, Request};
 use crate::BuildQueryParametersExt;
-use crate::Paginatable;
-use stellar_rust_sdk_derive::Pagination;
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents the request to fetch effects for a specific liquidity pool from the Horizon API.
 
@@ -36,19 +35,11 @@ use stellar_rust_sdk_derive::Pagination;
 /// // The request can now be used with a Horizon client to fetch effects.
 /// ```
 ///
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct EffectsForLiquidityPoolRequest {
     /// The liquidity pool id
     liquidity_pool_id: Option<String>,
-    /// A pointer to a specific location in a collection of responses, derived from the
-    ///   `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    ///   The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    ///   and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
 }
 
 impl EffectsForLiquidityPoolRequest {

--- a/stellar_rust_sdk/src/effects/effects_for_operation_request.rs
+++ b/stellar_rust_sdk/src/effects/effects_for_operation_request.rs
@@ -1,9 +1,8 @@
 use crate::{
     models::{Order, Request},
     BuildQueryParametersExt,
-    Paginatable,
 };
-use stellar_rust_sdk_derive::Pagination;
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents the request to fetch the effects for a specific operation from the Horizon API.
 ///
@@ -38,20 +37,11 @@ use stellar_rust_sdk_derive::Pagination;
 /// // The request can now be used with a Horizon client to fetch effects.
 /// ```
 ///
-
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct EffectsForOperationRequest {
     /// The operation id to filter effects.
     operation_id: Option<String>,
-    /// A pointer to a specific location in a collection of responses, derived from the
-    ///   `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    ///   The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    ///   and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
 }
 
 impl EffectsForOperationRequest {

--- a/stellar_rust_sdk/src/effects/effects_for_operation_request.rs
+++ b/stellar_rust_sdk/src/effects/effects_for_operation_request.rs
@@ -25,8 +25,6 @@ use stellar_rust_sdk_derive::pagination;
 /// ```rust
 /// # use stellar_rs::effects::effects_for_operation_request::EffectsForOperationRequest;
 /// # use stellar_rs::models::*;
-/// # use stellar_rust_sdk_derive::Pagination;
-/// # use stellar_rs::Paginatable;
 ///
 /// let request = EffectsForOperationRequest::new()
 ///     .set_operation_id("123")

--- a/stellar_rust_sdk/src/effects/effects_for_transaction_request.rs
+++ b/stellar_rust_sdk/src/effects/effects_for_transaction_request.rs
@@ -1,5 +1,5 @@
-use crate::{models::{Order, Request}, BuildQueryParametersExt, Paginatable};
-use stellar_rust_sdk_derive::Pagination;
+use crate::{models::{Order, Request}, BuildQueryParametersExt};
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents a request to fetch effect data from the Stellar Horizon API.
 ///
@@ -27,19 +27,11 @@ use stellar_rust_sdk_derive::Pagination;
 ///
 /// // The request can now be used with a Horizon client to fetch effects.
 /// ```
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct EffectForTransactionRequest {
     /// The transaction hash of the transaction of the effect
     transaction_hash: Option<String>,
-    /// A pointer to a specific location in a collection of responses, derived from the
-    ///   `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    ///   The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    ///   and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
 }
 
 impl EffectForTransactionRequest {

--- a/stellar_rust_sdk/src/effects/effects_for_transaction_request.rs
+++ b/stellar_rust_sdk/src/effects/effects_for_transaction_request.rs
@@ -16,8 +16,6 @@ use stellar_rust_sdk_derive::pagination;
 /// ```rust
 /// # use stellar_rs::effects::effects_for_transaction_request::EffectForTransactionRequest;
 /// # use stellar_rs::models::*;
-/// # use stellar_rust_sdk_derive::Pagination;
-/// # use stellar_rs::Paginatable;
 ///
 /// let request = EffectForTransactionRequest::new()
 ///     .set_transaction_hash("transaction_hash".to_string())

--- a/stellar_rust_sdk/src/effects/mod.rs
+++ b/stellar_rust_sdk/src/effects/mod.rs
@@ -119,7 +119,7 @@ pub mod prelude {
 #[cfg(test)]
 mod tests {
     use super::prelude::*;
-    use crate::{horizon_client::HorizonClient, Paginatable};
+    use crate::{horizon_client::HorizonClient};
 
     #[test]
     fn dummy_test() {

--- a/stellar_rust_sdk/src/horizon_client.rs
+++ b/stellar_rust_sdk/src/horizon_client.rs
@@ -569,8 +569,6 @@ impl HorizonClient {
     /// # use stellar_rs::ledgers::prelude::*;
     /// # use stellar_rs::models::Request;
     /// # use stellar_rs::horizon_client::HorizonClient;
-    /// # use stellar_rust_sdk_derive::Pagination;
-    /// # use stellar_rs::Paginatable;
     /// #
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
@@ -679,8 +677,6 @@ impl HorizonClient {
     /// # use stellar_rs::effects::prelude::*;
     /// # use stellar_rs::models::Request;
     /// # use stellar_rs::horizon_client::HorizonClient;
-    /// # use stellar_rust_sdk_derive::Pagination;
-    /// # use crate::stellar_rs::Paginatable;
     /// #
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
@@ -735,8 +731,6 @@ impl HorizonClient {
     /// # use stellar_rs::effects::prelude::*;
     /// # use stellar_rs::models::Request;
     /// # use stellar_rs::horizon_client::HorizonClient;
-    /// # use stellar_rust_sdk_derive::Pagination;
-    /// # use stellar_rs::Paginatable;
     ///
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
@@ -880,8 +874,6 @@ impl HorizonClient {
     /// # use stellar_rs::offers::prelude::*;
     /// # use stellar_rs::models::Request;
     /// # use stellar_rs::horizon_client::HorizonClient;
-    /// # use stellar_rust_sdk_derive::Pagination;
-    /// # use stellar_rs::Paginatable;
     /// #
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
@@ -959,8 +951,6 @@ impl HorizonClient {
     /// # use stellar_rs::operations::prelude::*;
     /// # use stellar_rs::models::Request;
     /// # use stellar_rs::horizon_client::HorizonClient;
-    /// # use stellar_rust_sdk_derive::Pagination;
-    /// # use stellar_rs::Paginatable;
     /// #
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
@@ -1057,7 +1047,6 @@ impl HorizonClient {
     /// # use stellar_rs::operations::prelude::*;
     /// # use stellar_rs::models::Request;
     /// # use stellar_rs::horizon_client::HorizonClient;
-    /// # use crate::stellar_rs::Paginatable;
     /// #
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
@@ -1758,8 +1747,6 @@ impl HorizonClient {
     /// # use stellar_rs::transactions::prelude::*;
     /// # use stellar_rs::models::{Request, IncludeFailed};
     /// # use stellar_rs::horizon_client::HorizonClient;
-    /// # use stellar_rust_sdk_derive::Pagination;
-    /// # use stellar_rs::Paginatable;
     /// #
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
@@ -1810,8 +1797,6 @@ impl HorizonClient {
     /// # use stellar_rs::transactions::prelude::*;
     /// # use stellar_rs::models::Request;
     /// # use stellar_rs::horizon_client::HorizonClient;
-    /// # use stellar_rust_sdk_derive::Pagination;
-    /// # use stellar_rs::Paginatable;
     /// #
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
@@ -1863,8 +1848,6 @@ impl HorizonClient {
     /// # use stellar_rs::transactions::prelude::*;
     /// # use stellar_rs::models::Request;
     /// # use stellar_rs::horizon_client::HorizonClient;
-    /// # use stellar_rust_sdk_derive::Pagination;
-    /// # use stellar_rs::Paginatable;
     /// #
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
@@ -1916,8 +1899,6 @@ impl HorizonClient {
     /// # use stellar_rs::transactions::prelude::*;
     /// # use stellar_rs::models::Request;
     /// # use stellar_rs::horizon_client::HorizonClient;
-    /// # use stellar_rust_sdk_derive::Pagination;
-    /// # use stellar_rs::Paginatable;
     /// #
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
@@ -1969,8 +1950,6 @@ impl HorizonClient {
     /// # use stellar_rs::payments::prelude::*;
     /// # use stellar_rs::models::Request;
     /// # use stellar_rs::horizon_client::HorizonClient;
-    /// # use stellar_rust_sdk_derive::Pagination;
-    /// # use stellar_rs::Paginatable;
     /// #
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
@@ -2021,8 +2000,6 @@ impl HorizonClient {
     /// # use stellar_rs::payments::prelude::*;
     /// # use stellar_rs::models::Request;
     /// # use stellar_rs::horizon_client::HorizonClient;
-    /// # use stellar_rust_sdk_derive::Pagination;
-    /// # use stellar_rs::Paginatable;
     ///
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
@@ -2073,8 +2050,6 @@ impl HorizonClient {
     /// # use stellar_rs::payments::prelude::*;
     /// # use stellar_rs::models::Request;
     /// # use stellar_rs::horizon_client::HorizonClient;
-    /// # use stellar_rust_sdk_derive::Pagination;
-    /// # use stellar_rs::Paginatable;
     ///
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();
@@ -2126,8 +2101,6 @@ impl HorizonClient {
     /// # use stellar_rs::payments::prelude::*;
     /// # use stellar_rs::models::Request;
     /// # use stellar_rs::horizon_client::HorizonClient;
-    /// # use stellar_rust_sdk_derive::Pagination;
-    /// # use stellar_rs::Paginatable;
     ///
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();

--- a/stellar_rust_sdk/src/horizon_client.rs
+++ b/stellar_rust_sdk/src/horizon_client.rs
@@ -1097,7 +1097,6 @@ impl HorizonClient {
     /// # use stellar_rs::operations::prelude::*;
     /// # use stellar_rs::models::Request;
     /// # use stellar_rs::horizon_client::HorizonClient;
-    /// # use crate::stellar_rs::Paginatable;
     /// #
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let base_url = "https://horizon-testnet.stellar.org".to_string();

--- a/stellar_rust_sdk/src/ledgers/ledgers_request.rs
+++ b/stellar_rust_sdk/src/ledgers/ledgers_request.rs
@@ -16,8 +16,6 @@ use stellar_rust_sdk_derive::pagination;
 /// ```rust
 /// # use stellar_rs::ledgers::ledgers_request::LedgersRequest;
 /// # use stellar_rs::models::*;
-/// # use stellar_rust_sdk_derive::Pagination;
-/// # use stellar_rs::Paginatable;
 ///
 /// let request = LedgersRequest::new()
 ///     .set_cursor(1234).unwrap()

--- a/stellar_rust_sdk/src/ledgers/ledgers_request.rs
+++ b/stellar_rust_sdk/src/ledgers/ledgers_request.rs
@@ -1,5 +1,5 @@
-use crate::{models::*, BuildQueryParametersExt, Paginatable};
-use stellar_rust_sdk_derive::Pagination;
+use crate::{models::*, BuildQueryParametersExt};
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents a request to fetch ledger data from the Stellar Horizon API.
 ///
@@ -27,19 +27,9 @@ use stellar_rust_sdk_derive::Pagination;
 /// // The request can now be used with a Horizon client to fetch ledgers.
 /// ```
 ///
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct LedgersRequest {
-    /// A pointer to a specific location in a collection of responses, derived from the
-    ///   `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-
-    /// Specifies the maximum number of records to be returned in a single response.
-    ///   The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u8>,
-
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    ///   and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
 }
 
 impl LedgersRequest {

--- a/stellar_rust_sdk/src/ledgers/ledgers_request.rs
+++ b/stellar_rust_sdk/src/ledgers/ledgers_request.rs
@@ -28,6 +28,7 @@ use stellar_rust_sdk_derive::pagination;
 #[pagination]
 #[derive(Default)]
 pub struct LedgersRequest {
+    // All fields are injected by the `pagination` macro.
 }
 
 impl LedgersRequest {

--- a/stellar_rust_sdk/src/ledgers/mod.rs
+++ b/stellar_rust_sdk/src/ledgers/mod.rs
@@ -85,7 +85,7 @@ pub mod prelude {
 #[cfg(test)]
 pub mod tests {
     use super::prelude::*;
-    use crate::{horizon_client::HorizonClient, Paginatable};
+    use crate::{horizon_client::HorizonClient};
     use base64::{engine::general_purpose, Engine};
 
     #[tokio::test]

--- a/stellar_rust_sdk/src/lib.rs
+++ b/stellar_rust_sdk/src/lib.rs
@@ -83,7 +83,6 @@
 //! types for more examples and detailed usage instructions.
 
 use derive_getters::Getters;
-use models::Order;
 /// Provides `Request` and `Response` structs for retrieving accounts.
 ///
 /// This module provides a set of specialized request and response structures designed for

--- a/stellar_rust_sdk/src/lib.rs
+++ b/stellar_rust_sdk/src/lib.rs
@@ -738,15 +738,3 @@ impl<T: ToString> BuildQueryParametersExt<Option<T>> for Vec<Option<T>> {
         }
     }
 }
-
-pub trait Paginatable {
-    fn set_cursor(self, cursor: u32) -> Result<Self, String>
-    where
-        Self: Sized;
-    fn set_limit(self, limit: u8) -> Result<Self, String>
-    where
-        Self: Sized;
-    fn set_order(self, order: Order) -> Result<Self, String>
-    where
-        Self: Sized;
-}

--- a/stellar_rust_sdk/src/lib.rs
+++ b/stellar_rust_sdk/src/lib.rs
@@ -251,8 +251,6 @@ pub mod horizon_client;
 /// # use stellar_rs::horizon_client::HorizonClient;
 /// # use stellar_rs::ledgers::prelude::*;
 /// # use stellar_rs::models::Request;
-/// # use stellar_rust_sdk_derive::Pagination;
-/// # use stellar_rs::Paginatable;
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let horizon_client = HorizonClient::new("https://horizon-testnet.stellar.org".to_string())?;
@@ -294,8 +292,6 @@ pub mod ledgers;
 /// # use stellar_rs::horizon_client::HorizonClient;
 /// # use stellar_rs::effects::prelude::*;
 /// # use stellar_rs::models::Request;
-/// # use stellar_rust_sdk_derive::Pagination;
-/// # use crate::stellar_rs::Paginatable;
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let horizon_client = HorizonClient::new("https://horizon-testnet.stellar.org".to_string())?;
@@ -449,8 +445,6 @@ pub mod offers;
 /// # use stellar_rs::horizon_client::HorizonClient;
 /// # use stellar_rs::operations::prelude::*;
 /// # use stellar_rs::models::Request;
-/// # use stellar_rust_sdk_derive::Pagination;
-/// # use stellar_rs::Paginatable;
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let horizon_client = HorizonClient::new("https://horizon-testnet.stellar.org".to_string())?;

--- a/stellar_rust_sdk/src/liquidity_pools/all_liquidity_pools_request.rs
+++ b/stellar_rust_sdk/src/liquidity_pools/all_liquidity_pools_request.rs
@@ -1,5 +1,5 @@
-use crate::{models::{Order, Request}, BuildQueryParametersExt, Paginatable};
-use stellar_rust_sdk_derive::Pagination;
+use crate::{models::{Order, Request}, BuildQueryParametersExt};
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents a reserve for a liquidity pool. This struct is used to specify the asset code and
 #[derive(PartialEq, Debug)]
@@ -46,17 +46,9 @@ pub enum ReserveType {
 /// // The request can now be used with a Horizon client to fetch liquidity pools.
 /// ```
 ///
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct AllLiquidityPoolsRequest {
-    /// A pointer to a specific location in a collection of responses, derived from the
-    ///   `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    ///   The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    ///   and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
     /// A list of reserves to filter by.
     reserves: Option<Vec<ReserveType>>,
 }

--- a/stellar_rust_sdk/src/liquidity_pools/all_liquidity_pools_request.rs
+++ b/stellar_rust_sdk/src/liquidity_pools/all_liquidity_pools_request.rs
@@ -33,8 +33,6 @@ pub enum ReserveType {
 /// ```rust
 /// # use stellar_rs::liquidity_pools::all_liquidity_pools_request::AllLiquidityPoolsRequest;
 /// # use stellar_rs::models::*;
-/// # use stellar_rust_sdk_derive::Pagination;
-/// # use stellar_rs::Paginatable;
 ///
 /// let request = AllLiquidityPoolsRequest::new()
 ///     .set_cursor(1234).unwrap()

--- a/stellar_rust_sdk/src/liquidity_pools/mod.rs
+++ b/stellar_rust_sdk/src/liquidity_pools/mod.rs
@@ -70,7 +70,7 @@ pub mod prelude {
 
 #[tokio::test]
 async fn test_get_all_liquidity_pools() {
-    use crate::{horizon_client::HorizonClient, Paginatable};
+    use crate::{horizon_client::HorizonClient};
     use all_liquidity_pools_request::AllLiquidityPoolsRequest;
 
 

--- a/stellar_rust_sdk/src/offers/all_offers_request.rs
+++ b/stellar_rust_sdk/src/offers/all_offers_request.rs
@@ -1,6 +1,5 @@
 use crate::{models::*, BuildQueryParametersExt};
-use stellar_rust_sdk_derive::Pagination;
-use crate::Paginatable;
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents a request to list all offers from the Stellar Horizon API.
 ///
@@ -34,7 +33,8 @@ use crate::Paginatable;
 /// // Use with HorizonClient::get_all_offers
 /// ```
 ///
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct AllOffersRequest {
     /// Optional. The ID of the sponsor. When set, the response will
     /// only include offers sponsored by the specified account.
@@ -48,15 +48,6 @@ pub struct AllOffersRequest {
     /// Optional. Indicates a buying asset for which offers are being queried.
     /// When set, the response will filter the offers that hold this specific asset.
     buying: Option<Asset<IssuedAsset>>,
-    /// A pointer to a specific location in a collection of responses, derived from the
-    /// `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    /// The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    /// and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
 }
 
 impl Request for AllOffersRequest {

--- a/stellar_rust_sdk/src/offers/all_offers_request.rs
+++ b/stellar_rust_sdk/src/offers/all_offers_request.rs
@@ -18,8 +18,6 @@ use stellar_rust_sdk_derive::pagination;
 /// ```
 /// use stellar_rs::offers::all_offers_request::AllOffersRequest;
 /// use stellar_rs::models::{Asset, NativeAsset, Order};
-/// use stellar_rust_sdk_derive::Pagination;
-/// use stellar_rs::Paginatable;
 ///
 /// let request = AllOffersRequest::new()
 ///     .set_sponsor("GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5".to_string()).unwrap() // Optional sponsor filter

--- a/stellar_rust_sdk/src/offers/mod.rs
+++ b/stellar_rust_sdk/src/offers/mod.rs
@@ -83,7 +83,7 @@ pub mod prelude {
 #[cfg(test)]
 pub mod test {
     use super::prelude::*;
-    use crate::{horizon_client::HorizonClient, models::*, Paginatable};
+    use crate::{horizon_client::HorizonClient, models::*};
 
     #[tokio::test]
     async fn test_get_single_offer() {

--- a/stellar_rust_sdk/src/offers/offers_for_account_request.rs
+++ b/stellar_rust_sdk/src/offers/offers_for_account_request.rs
@@ -1,6 +1,5 @@
 use crate::models::*;
-use stellar_rust_sdk_derive::Pagination;
-use crate::Paginatable;
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents the ID of an account for which the offers are to be retrieved.
 #[derive(Default, Clone)]
@@ -9,21 +8,12 @@ pub struct OfferAccountId(String);
 /// Represents the absence of the ID of an account for which the offers are to be retrieved.
 #[derive(Default, Clone)]
 pub struct NoOfferAccountId;
-#[derive(Default)]
 
-#[derive(Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct OffersForAccountRequest<I> {
     /// The ID of the account for which the offers are to be retrieved.
     account_id: I,
-    /// A pointer to a specific location in a collection of responses, derived from the
-    /// `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    /// The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    /// and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
 }
 
 impl OffersForAccountRequest<NoOfferAccountId> {

--- a/stellar_rust_sdk/src/operations/all_operations_request.rs
+++ b/stellar_rust_sdk/src/operations/all_operations_request.rs
@@ -1,21 +1,9 @@
 use crate::models::{IncludeFailed, Order, Request};
-use crate::Paginatable;
-use stellar_rust_sdk_derive::Pagination;
+use stellar_rust_sdk_derive::pagination;
 
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct AllOperationsRequest {
-    /// A pointer to a specific location in a collection of responses, derived from the
-    ///   `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-
-    /// Specifies the maximum number of records to be returned in a single response.
-    ///   The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u8>,
-
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    ///   and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
-
     /// A boolean value that determines whether to include failed operations in the response.
     include_failed: Option<IncludeFailed>,
 }

--- a/stellar_rust_sdk/src/operations/mod.rs
+++ b/stellar_rust_sdk/src/operations/mod.rs
@@ -121,8 +121,17 @@ pub mod prelude {
 
 #[cfg(test)]
 pub mod tests {
-    use super::prelude::*;
-    use crate::{horizon_client::HorizonClient, Paginatable};
+    use crate::{
+        horizon_client,
+        operations::{
+            operations_for_account_request::OperationsForAccountRequest,
+            prelude::{
+                AllOperationsRequest, OperationsForLedgerRequest, OperationsForLiquidityPoolRequest,
+            },
+            response::{Operation, OperationResponse},
+            single_operation_request::SingleOperationRequest,
+        },
+    };
 
     #[tokio::test]
     async fn test_get_all_operations() {

--- a/stellar_rust_sdk/src/operations/mod.rs
+++ b/stellar_rust_sdk/src/operations/mod.rs
@@ -122,12 +122,14 @@ pub mod prelude {
 #[cfg(test)]
 pub mod tests {
     use crate::{
-        horizon_client,
+        horizon_client::*,
         operations::{
             operations_for_account_request::OperationsForAccountRequest,
             prelude::{
-                AllOperationsRequest, OperationsForLedgerRequest, OperationsForLiquidityPoolRequest,
-            },
+                AllOperationsRequest,
+                OperationsForLedgerRequest,
+                OperationsForLiquidityPoolRequest,
+                OperationsForTransactionRequest,            },
             response::{Operation, OperationResponse},
             single_operation_request::SingleOperationRequest,
         },

--- a/stellar_rust_sdk/src/operations/operations_for_account_request.rs
+++ b/stellar_rust_sdk/src/operations/operations_for_account_request.rs
@@ -2,32 +2,18 @@ use crate::{
     models::{IncludeFailed, Order, Request},
     BuildQueryParametersExt,
 };
+use stellar_rust_sdk_derive::pagination;
 
-use stellar_rust_sdk_derive::Pagination;
-use crate::Paginatable;
-
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct OperationsForAccountRequest {
     /// The account ID for which to retrieve operations.
     account_id: Option<String>,
-
-    /// A pointer to a specific location in a collection of responses, derived from the
-    ///   `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-
-    /// Specifies the maximum number of records to be returned in a single response.
-    ///   The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u8>,
-
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    ///   and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
-
     /// A boolean value that determines whether to include failed operations in the response.
     include_failed: Option<IncludeFailed>,
 }
 
-// 
+ 
 impl OperationsForAccountRequest {
     pub fn new() -> Self {
         OperationsForAccountRequest::default()

--- a/stellar_rust_sdk/src/operations/operations_for_ledger_request.rs
+++ b/stellar_rust_sdk/src/operations/operations_for_ledger_request.rs
@@ -1,28 +1,14 @@
-use stellar_rust_sdk_derive::Pagination;
-use crate::Paginatable;
-
+use stellar_rust_sdk_derive::pagination;
 use crate::{
     models::{IncludeFailed, Order, Request},
     BuildQueryParametersExt,
 };
 
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct OperationsForLedgerRequest {
     /// The account ID for which to retrieve operations.
     ledger_sequence: Option<String>,
-
-    /// A pointer to a specific location in a collection of responses, derived from the
-    ///   `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-
-    /// Specifies the maximum number of records to be returned in a single response.
-    ///   The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u8>,
-
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    ///   and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
-
     /// A boolean value that determines whether to include failed operations in the response.
     include_failed: Option<IncludeFailed>,
 }

--- a/stellar_rust_sdk/src/operations/operations_for_liquidity_pool_request.rs
+++ b/stellar_rust_sdk/src/operations/operations_for_liquidity_pool_request.rs
@@ -1,25 +1,14 @@
-use stellar_rust_sdk_derive::Pagination;
-use crate::Paginatable;
-
+use stellar_rust_sdk_derive::pagination;
 use crate::{
     models::{IncludeFailed, Order, Request},
     BuildQueryParametersExt,
 };
 
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct OperationsForLiquidityPoolRequest {
     /// A unique identifier for the liquidity pool of the operation(s).
     liquidity_pool_id: Option<String>,
-    /// A number that points to a specific location in a collection of responses and is pulled
-    /// from the paging_token value of a record.
-    cursor: Option<u32>,
-    /// The maximum number of records returned. The limit can range from 1 to 200 - an upper limit
-    /// that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it
-    /// defaults to 10.
-    limit: Option<u8>,
-    /// A designation of the [`Order`] in which records should appear. Options include [`Order::Asc`] (ascending)
-    /// or [`Order::Desc`] (descending). If this argument isn’t set, it defaults to asc.
-    order: Option<Order>,
     /// Set to true to include failed operations in results. Options include true and false.
     include_failed: Option<IncludeFailed>,
 }

--- a/stellar_rust_sdk/src/operations/operations_for_transaction_request.rs
+++ b/stellar_rust_sdk/src/operations/operations_for_transaction_request.rs
@@ -1,25 +1,15 @@
-use stellar_rust_sdk_derive::Pagination;
-use crate::Paginatable;
+use stellar_rust_sdk_derive::pagination;
 
 use crate::{
     models::{Order, Request},
     BuildQueryParametersExt,
 };
 
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct OperationsForTransactionRequest {
     /// The hash of the transaction. Optional.
     transaction_hash: Option<String>,
-    /// A number that points to a specific location in a collection of responses and is pulled
-    /// from the paging_token value of a record.
-    cursor: Option<u32>,
-    /// The maximum number of records returned. The limit can range from 1 to 200 - an upper limit
-    /// that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it
-    /// defaults to 10.
-    limit: Option<u8>,
-    /// A designation of the [`Order`] in which records should appear. Options include [`Order::Asc`] (ascending)
-    /// or [`Order::Desc`] (descending). If this argument isn’t set, it defaults to asc.
-    order: Option<Order>,
 }
 
 impl OperationsForTransactionRequest {

--- a/stellar_rust_sdk/src/payments/all_payments_request.rs
+++ b/stellar_rust_sdk/src/payments/all_payments_request.rs
@@ -5,6 +5,7 @@ use stellar_rust_sdk_derive::pagination;
 #[pagination]
 #[derive(Default)]
 pub struct AllPaymentsRequest {
+    // All fields are injected by the `pagination` macro.
 }
 
 impl AllPaymentsRequest {

--- a/stellar_rust_sdk/src/payments/all_payments_request.rs
+++ b/stellar_rust_sdk/src/payments/all_payments_request.rs
@@ -1,18 +1,10 @@
 use crate::models::{Order, Request};
-use crate::{BuildQueryParametersExt, Paginatable};
-use stellar_rust_sdk_derive::Pagination;
+use crate::BuildQueryParametersExt;
+use stellar_rust_sdk_derive::pagination;
 
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct AllPaymentsRequest {
-    /// A pointer to a specific location in a collection of responses, derived from the
-    ///   `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    ///   The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    ///   and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
 }
 
 impl AllPaymentsRequest {

--- a/stellar_rust_sdk/src/payments/mod.rs
+++ b/stellar_rust_sdk/src/payments/mod.rs
@@ -56,7 +56,7 @@ pub mod prelude {
 #[cfg(test)]
 pub mod test {
     use super::prelude::*;
-    use crate::{horizon_client::HorizonClient, models::IncludeFailed, Paginatable};
+    use crate::{horizon_client::HorizonClient, models::IncludeFailed};
 
     static ID: &str = "2314987376641";
     static PAGING_TOKEN: &str = "2314987376641";

--- a/stellar_rust_sdk/src/payments/payments_for_account_request.rs
+++ b/stellar_rust_sdk/src/payments/payments_for_account_request.rs
@@ -1,20 +1,13 @@
 use crate::models::{IncludeFailed, Order, Request};
 use crate::payments::PAYMENTS_PATH;
-use crate::{BuildQueryParametersExt, Paginatable};
-use stellar_rust_sdk_derive::Pagination;
+use crate::BuildQueryParametersExt;
+use stellar_rust_sdk_derive::pagination;
 
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct PaymentsForAccountRequest {
     /// The Stellar address of the account for which you want to retrieve payments.
     account_id: Option<String>,
-    /// A pointer to a specific location in a collection of responses, derived from the
-    ///  `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    /// and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
     /// A boolean value that determines whether failed transactions should be included in the response.
     include_failed: Option<IncludeFailed>,
 }

--- a/stellar_rust_sdk/src/payments/payments_for_ledger_request.rs
+++ b/stellar_rust_sdk/src/payments/payments_for_ledger_request.rs
@@ -1,20 +1,13 @@
 use crate::models::{IncludeFailed, Order, Request};
 use crate::payments::PAYMENTS_PATH;
-use crate::{BuildQueryParametersExt, Paginatable};
-use stellar_rust_sdk_derive::Pagination;
+use crate::BuildQueryParametersExt;
+use stellar_rust_sdk_derive::pagination;
 
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct PaymentsForLedgerRequest {
     /// The Stellar address of the account for which you want to retrieve payments.
     ledger_sequence: Option<String>,
-    /// A pointer to a specific location in a collection of responses, derived from the
-    ///  `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    /// and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
     /// A boolean value that determines whether failed transactions should be included in the response.
     include_failed: Option<IncludeFailed>,
 }

--- a/stellar_rust_sdk/src/payments/payments_for_transaction_request.rs
+++ b/stellar_rust_sdk/src/payments/payments_for_transaction_request.rs
@@ -1,21 +1,13 @@
 use crate::models::{Order, Request};
 use crate::payments::PAYMENTS_PATH;
-use crate::{BuildQueryParametersExt, Paginatable};
-use stellar_rust_sdk_derive::Pagination;
+use crate::BuildQueryParametersExt;
+use stellar_rust_sdk_derive::pagination;
 
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct PaymentsForTransactionRequest {
     /// The transaction hash of the transaction for which you want to retrieve payments.
     transaction_hash: Option<String>,
-    /// A pointer to a specific location in a collection of responses, derived from the
-    ///   `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    ///   The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    ///   and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
 }
 
 impl PaymentsForTransactionRequest {

--- a/stellar_rust_sdk/src/trade_aggregations/trade_aggregations_request.rs
+++ b/stellar_rust_sdk/src/trade_aggregations/trade_aggregations_request.rs
@@ -81,7 +81,7 @@ impl std::fmt::Display for ResolutionData {
 ///
 /// # Example
 /// ```
-/// use stellar_rs::{trade_aggregations::prelude::*, models::*, Paginatable};
+/// use stellar_rs::{trade_aggregations::prelude::*, models::*};
 ///
 /// let request = TradeAggregationsRequest::new()
 ///     .set_base_asset(AssetType::Native).unwrap()

--- a/stellar_rust_sdk/src/trades/all_trades_request.rs
+++ b/stellar_rust_sdk/src/trades/all_trades_request.rs
@@ -38,8 +38,7 @@ pub enum AssetType {
 ///
 /// # Example
 /// ```
-/// use stellar_rs::{trades::prelude::*, models::*, Paginatable};
-/// use stellar_rust_sdk_derive::Pagination;
+/// use stellar_rs::{trades::prelude::*, models::*};
 ///
 /// let request = AllTradesRequest::new()
 ///     .set_base_asset(AssetType::Native).unwrap() // Optional selling asset filter

--- a/stellar_rust_sdk/src/trades/all_trades_request.rs
+++ b/stellar_rust_sdk/src/trades/all_trades_request.rs
@@ -1,6 +1,5 @@
 use crate::models::*;
-use stellar_rust_sdk_derive::Pagination;
-use crate::Paginatable;
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents the base and counter assets. Contains an enum of one of the possible asset types.
 #[derive(PartialEq, Debug)]
@@ -51,7 +50,8 @@ pub enum AssetType {
 /// // Use with HorizonClient::get_all_offers
 /// ```
 ///
-#[derive(PartialEq, Default, Pagination)]
+#[pagination]
+#[derive(PartialEq, Default)]
 pub struct AllTradesRequest {
     /// The base asset of the trade.
     pub base_asset: Option<TradeAsset>,
@@ -59,17 +59,7 @@ pub struct AllTradesRequest {
     pub counter_asset: Option<TradeAsset>,
     // The offer ID. Used to filter for trades originating from a specific offer.
     pub offer_id: Option<String>,
-    /// A pointer to a specific location in a collection of responses, derived from the
-    /// `paging_token` value of a record. Used for pagination control in the API response.
-    pub cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    /// The range for this parameter is from 1 to 200. The default value is set to 10.
-    pub limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    /// and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    pub order: Option<Order>,
 }
-
 
 impl AllTradesRequest {
     /// Creates a new `AllOffersRequest` with default parameters.

--- a/stellar_rust_sdk/src/trades/trades_for_account_request.rs
+++ b/stellar_rust_sdk/src/trades/trades_for_account_request.rs
@@ -1,6 +1,5 @@
 use crate::models::*;
-use stellar_rust_sdk_derive::Pagination;
-use crate::Paginatable;
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents the ID of an account for which the trades are to be retrieved.
 #[derive(Default, Clone)]
@@ -10,19 +9,11 @@ pub struct TradeAccountId(String);
 #[derive(Default, Clone)]
 pub struct NoTradeAccountId;
 
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct TradesForAccountRequest<I> {
     /// The ID of the account for which the trades are to be retrieved.
     account_id: I,
-    /// A pointer to a specific location in a collection of responses, derived from the
-    /// `paging_token` value of a record. Used for pagination control in the API response.
-    pub cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    /// The range for this parameter is from 1 to 200. The default value is set to 10.
-    pub limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    /// and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    pub order: Option<Order>,
 }
 
 impl TradesForAccountRequest<NoTradeAccountId> {

--- a/stellar_rust_sdk/src/trades/trades_for_liquidity_pool_request.rs
+++ b/stellar_rust_sdk/src/trades/trades_for_liquidity_pool_request.rs
@@ -1,6 +1,5 @@
 use crate::models::*;
-use stellar_rust_sdk_derive::Pagination;
-use crate::Paginatable;
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents the ID of a liquidity pool for which the trades are to be retrieved.
 #[derive(Default, Clone)]
@@ -10,19 +9,11 @@ pub struct TradeLiquidityPoolId(String);
 #[derive(Default, Clone)]
 pub struct NoTradeLiquidityPoolId;
 
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct TradesForLiquidityPoolRequest<I> {
     /// The ID of the liquidity pool for which the trades are to be retrieved.
     liquidity_pool_id: I,
-    /// A pointer to a specific location in a collection of responses, derived from the
-    /// `paging_token` value of a record. Used for pagination control in the API response.
-    pub cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    /// The range for this parameter is from 1 to 200. The default value is set to 10.
-    pub limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    /// and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    pub order: Option<Order>,
 }
 
 impl TradesForLiquidityPoolRequest<TradeLiquidityPoolId> {

--- a/stellar_rust_sdk/src/trades/trades_for_offer_request.rs
+++ b/stellar_rust_sdk/src/trades/trades_for_offer_request.rs
@@ -1,6 +1,5 @@
 use crate::models::*;
-use stellar_rust_sdk_derive::Pagination;
-use crate::Paginatable;
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents the ID of an offer for which the trades are to be retrieved.
 #[derive(Default, Clone)]
@@ -10,19 +9,11 @@ pub struct TradeOfferId(String);
 #[derive(Default, Clone)]
 pub struct NoTradeOfferId;
 
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct TradesForOfferRequest<I> {
     /// The ID of the offer for which the trades are to be retrieved.
     offer_id: I,
-    /// A pointer to a specific location in a collection of responses, derived from the
-    /// `paging_token` value of a record. Used for pagination control in the API response.
-    pub cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    /// The range for this parameter is from 1 to 200. The default value is set to 10.
-    pub limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    /// and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    pub order: Option<Order>,
 }
 
 impl TradesForOfferRequest<TradeOfferId> {

--- a/stellar_rust_sdk/src/transactions/all_transactions_request.rs
+++ b/stellar_rust_sdk/src/transactions/all_transactions_request.rs
@@ -1,6 +1,5 @@
 use crate::{models::*, BuildQueryParametersExt};
-use stellar_rust_sdk_derive::Pagination;
-use crate::Paginatable;
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents a request to list all transactions from the Stellar Horizon API.
 ///
@@ -31,19 +30,11 @@ use crate::Paginatable;
 /// // Use with HorizonClient::get_all_transactions
 /// ```
 ///
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct AllTransactionsRequest {
     // Indicates whether or not to include failed operations in the response.
     include_failed: Option<IncludeFailed>,
-    /// A pointer to a specific location in a collection of responses, derived from the
-    /// `paging_token` value of a record. Used for pagination control in the API response.
-    cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    /// The range for this parameter is from 1 to 200. The default value is set to 10.
-    limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    /// and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    order: Option<Order>,
 }
 
 impl Request for AllTransactionsRequest {

--- a/stellar_rust_sdk/src/transactions/all_transactions_request.rs
+++ b/stellar_rust_sdk/src/transactions/all_transactions_request.rs
@@ -18,8 +18,6 @@ use stellar_rust_sdk_derive::pagination;
 /// ```
 /// use stellar_rs::transactions::all_transactions_request::AllTransactionsRequest;
 /// use stellar_rs::models::{Order, IncludeFailed};
-/// use stellar_rust_sdk_derive::Pagination;
-/// use stellar_rs::Paginatable;
 ///
 /// let request = AllTransactionsRequest::new()
 ///     .set_include_failed(IncludeFailed::True).unwrap() // Optional flag to include failed transactions

--- a/stellar_rust_sdk/src/transactions/transactions_for_account_request.rs
+++ b/stellar_rust_sdk/src/transactions/transactions_for_account_request.rs
@@ -1,6 +1,5 @@
 use crate::{models::*, BuildQueryParametersExt};
-use stellar_rust_sdk_derive::Pagination;
-use crate::Paginatable;
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents the ID of an account for which the transactions are to be retrieved.
 #[derive(Default, Clone)]
@@ -10,21 +9,13 @@ pub struct TransactionsAccountId(String);
 #[derive(Default, Clone)]
 pub struct NoTransactionsAccountId;
 
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct TransactionsForAccountRequest<I> {
     /// The ID of the account for which the transactions are to be retrieved.
     account_id: I,
     // Indicates whether or not to include failed operations in the response.
     include_failed: Option<bool>,
-    /// A pointer to a specific location in a collection of responses, derived from the
-    /// `paging_token` value of a record. Used for pagination control in the API response.
-    pub cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    /// The range for this parameter is from 1 to 200. The default value is set to 10.
-    pub limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    /// and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    pub order: Option<Order>,
 }
 
 impl TransactionsForAccountRequest<NoTransactionsAccountId> {

--- a/stellar_rust_sdk/src/transactions/transactions_for_ledger_request.rs
+++ b/stellar_rust_sdk/src/transactions/transactions_for_ledger_request.rs
@@ -1,6 +1,5 @@
 use crate::{models::*, BuildQueryParametersExt};
-use stellar_rust_sdk_derive::Pagination;
-use crate::Paginatable;
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents the ID of a ledger for which the transactions are to be retrieved.
 #[derive(Default, Clone)]
@@ -10,21 +9,13 @@ pub struct TransactionsLedgerId(String);
 #[derive(Default, Clone)]
 pub struct NoTransactionsLedgerId;
 
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct TransactionsForLedgerRequest<S> {
     /// The ID of the ledger for which the transactions are to be retrieved.
     ledger_sequence: S,
     // Indicates whether or not to include failed operations in the response.
     include_failed: Option<bool>,
-    /// A pointer to a specific location in a collection of responses, derived from the
-    /// `paging_token` value of a record. Used for pagination control in the API response.
-    pub cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    /// The range for this parameter is from 1 to 200. The default value is set to 10.
-    pub limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    /// and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    pub order: Option<Order>,
 }
 
 impl TransactionsForLedgerRequest<NoTransactionsLedgerId> {

--- a/stellar_rust_sdk/src/transactions/transactions_for_liquidity_pool_request.rs
+++ b/stellar_rust_sdk/src/transactions/transactions_for_liquidity_pool_request.rs
@@ -1,6 +1,5 @@
 use crate::{models::*, BuildQueryParametersExt};
-use stellar_rust_sdk_derive::Pagination;
-use crate::Paginatable;
+use stellar_rust_sdk_derive::pagination;
 
 /// Represents the ID of a liquidity pool for which the transactions are to be retrieved.
 #[derive(Default, Clone)]
@@ -10,21 +9,13 @@ pub struct TransactionsLiquidityPoolId(String);
 #[derive(Default, Clone)]
 pub struct NoTransactionsLiquidityPoolId;
 
-#[derive(Default, Pagination)]
+#[pagination]
+#[derive(Default)]
 pub struct TransactionsForLiquidityPoolRequest<I> {
     /// The ID of the liquidity pool for which the transactions are to be retrieved.
     liquidity_pool_id: I,
     // Indicates whether or not to include failed operations in the response.
     include_failed: Option<bool>,
-    /// A pointer to a specific location in a collection of responses, derived from the
-    /// `paging_token` value of a record. Used for pagination control in the API response.
-    pub cursor: Option<u32>,
-    /// Specifies the maximum number of records to be returned in a single response.
-    /// The range for this parameter is from 1 to 200. The default value is set to 10.
-    pub limit: Option<u8>,
-    /// Determines the [`Order`] of the records in the response. Valid options are [`Order::Asc`] (ascending)
-    /// and [`Order::Desc`] (descending). If not specified, it defaults to ascending.
-    pub order: Option<Order>,
 }
 
 impl TransactionsForLiquidityPoolRequest<NoTransactionsLiquidityPoolId> {

--- a/stellar_rust_sdk_derive/src/lib.rs
+++ b/stellar_rust_sdk_derive/src/lib.rs
@@ -29,7 +29,7 @@ pub fn pagination(_attr: TokenStream, input: TokenStream) -> TokenStream {
     let expanded = quote! {
         #input
         impl #impl_generics #struct_name #type_generics #where_clause {
-            fn set_cursor(self, cursor: u32) -> Result<Self, String> {
+            pub fn set_cursor(self, cursor: u32) -> Result<Self, String> {
                 // Always accept the cursor since it's non-optional in the setter
                 if cursor < 1 {
                     return Err("Cursor must be greater than or equal to 1.".to_string());
@@ -38,7 +38,7 @@ pub fn pagination(_attr: TokenStream, input: TokenStream) -> TokenStream {
                 Ok(Self { cursor: Some(cursor), ..self })
             }
 
-            fn set_limit(self, limit: u8) -> Result<Self, String> {
+            pub fn set_limit(self, limit: u8) -> Result<Self, String> {
                 // Validate limit if necessary
                 if !(1..=200).contains(&limit) {
                     Err("Limit must be between 1 and 200.".to_string())
@@ -47,7 +47,7 @@ pub fn pagination(_attr: TokenStream, input: TokenStream) -> TokenStream {
                 }
             }
 
-            fn set_order(self, order: Order) -> Result<Self, String> {
+            pub fn set_order(self, order: Order) -> Result<Self, String> {
                 // No validation required for setting the order in this context
                 Ok(Self { order: Some(order), ..self })
             }

--- a/stellar_rust_sdk_derive/src/lib.rs
+++ b/stellar_rust_sdk_derive/src/lib.rs
@@ -3,11 +3,35 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, ItemStruct, Fields, Field};
 
+/// The procedural attribute macro to add pagination functionality to request structs.
+///
+/// This macro automatically injects pagination-related fields and methods into a struct
+/// to facilitate paginated API requests. Specifically, it adds three optional fields
+/// and three methods:
+///
+/// - `cursor`: An `Option<u32>` field that represents the pagination cursor. The cursor
+///   is used to track the current position in a paginated dataset. The `set_cursor` method
+///   allows setting this field, with a validation that ensures the cursor is greater than
+///   or equal to 1.
+///
+/// - `limit`: An `Option<u8>` field that specifies the maximum number of items to retrieve
+///   in a single page. The `set_limit` method allows setting this field, ensuring that the
+///   limit is within a valid range (between 1 and 200).
+///
+/// - `order`: An `Option<Order>` field that defines the sort order of the paginated results.
+///   The `set_order` method allows setting this field without additional validation, as the
+///   sort order is context-dependent.
+///
+/// # Usage
+///
+/// Apply the `#[pagination]` attribute to a struct to automatically add pagination
+/// functionality.
+///
 #[proc_macro_attribute]
 pub fn pagination(_attr: TokenStream, input: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(input as ItemStruct);
 
-    // create req'd fields
+    // Create required fields to be added to the struct.
     let cursor_field: Field = syn::parse_quote! {
         pub cursor: Option<u32>
     };
@@ -18,6 +42,7 @@ pub fn pagination(_attr: TokenStream, input: TokenStream) -> TokenStream {
         pub order: Option<Order>
     };
 
+    // Add the fields to the struct.
     if let Fields::Named(ref mut fields) = input.fields {
         fields.named.push(cursor_field);
         fields.named.push(limit_field);
@@ -25,7 +50,11 @@ pub fn pagination(_attr: TokenStream, input: TokenStream) -> TokenStream {
     }
 
     let struct_name = &input.ident;
+
+    // Split the generics into implementation, type, and where clause parts, so that the macro supports generic structs.
     let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
+
+    // Add methods to the struct.
     let expanded = quote! {
         #input
         impl #impl_generics #struct_name #type_generics #where_clause {

--- a/stellar_rust_sdk_derive/src/lib.rs
+++ b/stellar_rust_sdk_derive/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate proc_macro2;
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, ItemStruct, Fields, Field};
+use syn::{parse_macro_input, ItemStruct, Fields, Field, parse::Nothing};
 
 /// The procedural attribute macro to add pagination functionality to request structs.
 ///
@@ -28,8 +28,11 @@ use syn::{parse_macro_input, ItemStruct, Fields, Field};
 /// functionality.
 ///
 #[proc_macro_attribute]
-pub fn pagination(_attr: TokenStream, input: TokenStream) -> TokenStream {
+pub fn pagination(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(input as ItemStruct);
+
+    // No arguments should be passed, but if they are, parse them as `Nothing` to prevent misuse. 
+    let _ = parse_macro_input!(args as Nothing);
 
     // Create required fields to be added to the struct.
     let cursor_field: Field = syn::parse_quote! {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fixes #81, #82 and #66.

Changes the **derive** macro for pagination functionality to an **attribute** macro. In addition to injecting the 3 methods for pagination, the macro now also injects the 3 required fields. Updates all implementations of this macro.

Since a `Paginatable` trait is no longer necessary and undesirable as per issue #81, this is also removed.

Adds documentation and comments.

Note: since the macro is named specifically `stellar_rust_sdk_derive` but is now an attribute macro, we should probably change the name accordingly.

### :memo: Links to relevant issues/docs
https://users.rust-lang.org/t/solved-derive-and-proc-macro-add-field-to-an-existing-struct/52307/4
https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current main
